### PR TITLE
컨트롤러에서 UserID를 User 객체로 반환

### DIFF
--- a/src/main/java/com/example/newsfeedproject/auth/controller/AuthController.java
+++ b/src/main/java/com/example/newsfeedproject/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.example.newsfeedproject.auth.controller;
 
 import com.example.newsfeedproject.auth.service.AuthService;
+import com.example.newsfeedproject.common.annoation.LoginUserResolver;
 import com.example.newsfeedproject.user.dto.DeleteUserRequest;
 import com.example.newsfeedproject.user.dto.SignupRequest;
 import com.example.newsfeedproject.user.dto.UserResponse;
@@ -32,14 +33,8 @@ public class AuthController {
      **/
     @DeleteMapping("/withdraw")
     public ResponseEntity<UserResponse> withdraw(
-            @SessionAttribute(name = "LOGIN_USER", required = false) User user,
+            @LoginUserResolver User user,
             @Valid @RequestBody DeleteUserRequest request) {
-
-        // 로그인 상태 체크
-        if (user == null) {
-            // 로그인 되지 않으면 상태 코드 반환
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
 
         // 로그인된 사용자인 경우, 서비스 로직 호출
         authService.withdraw(user.getEmail(), request);

--- a/src/main/java/com/example/newsfeedproject/common/annoation/LoginUserResolver.java
+++ b/src/main/java/com/example/newsfeedproject/common/annoation/LoginUserResolver.java
@@ -1,0 +1,11 @@
+package com.example.newsfeedproject.common.annoation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUserResolver {
+}

--- a/src/main/java/com/example/newsfeedproject/common/config/UserHandlerArgumentResolver.java
+++ b/src/main/java/com/example/newsfeedproject/common/config/UserHandlerArgumentResolver.java
@@ -1,0 +1,44 @@
+package com.example.newsfeedproject.common.config;
+
+import com.example.newsfeedproject.user.entity.User;
+import com.example.newsfeedproject.user.repository.UserRepository;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.Objects;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class UserHandlerArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final HttpSession httpSession;
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(User.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+
+        Object userId = httpSession.getAttribute("LOGIN_USER");
+
+        if (Objects.isNull(userId)) {
+            throw new Exception("유저를 찾을 수 없습니다.");
+        }
+
+        Optional<User> optionalUser = userRepository.findById((Long) userId);
+        return optionalUser.orElseThrow(() -> new Exception("유저를 찾을 수 없습니다."));
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
- HandlerMethodArgumentResolver를 상속받은 구현체 UserHandlerArgumentResolver 추가
- LoginUserResolver 어노테이션 추가
- AuthController의 "LoginUserResolver" 어노테이션 파라미터 적용

## 🔗 연관된 이슈
Related to: #21 

리뷰 요구사항
- 만약 컨트롤러 구현중이신게 있으면 해당 내용을 더 참고해보시면 될 것 같습니다.
- session에 들어있는 "LOGIN_USER"값이 있으면 Entity 객체로 반환받습니다.

## ✅ PR 유형

- [x] 새로운 기능 추가
- [x] 코드 리팩토링