### PR TITLE
feat: 전체 게시물 조회 (페이지네이션)

### DIFF
--- a/src/main/java/com/example/newsfeedproject/mapper/PostMapper.java
+++ b/src/main/java/com/example/newsfeedproject/mapper/PostMapper.java
@@ -3,11 +3,19 @@ package com.example.newsfeedproject.mapper;
 import com.example.newsfeedproject.post.dto.PostRequest;
 import com.example.newsfeedproject.post.dto.PostResponse;
 import com.example.newsfeedproject.post.entity.Post;
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.Named;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface PostMapper {
 
     Post toEntity(PostRequest postRequest);
+    @Named("toResponse(Post)")
     PostResponse toResponse(Post post);
+    @IterableMapping(qualifiedByName = "toResponse(Post)")
+    List<PostResponse> toListResponse(Page<Post> posts);
 }

--- a/src/main/java/com/example/newsfeedproject/post/controller/PostController.java
+++ b/src/main/java/com/example/newsfeedproject/post/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.example.newsfeedproject.post.controller;
 
+import com.example.newsfeedproject.post.dto.PostListResponse;
 import com.example.newsfeedproject.post.dto.PostRequest;
 import com.example.newsfeedproject.post.dto.PostResponse;
 import com.example.newsfeedproject.post.dto.UpdatePostContentRequest;
@@ -34,7 +35,7 @@ public class PostController {
      * 전체 게시물 조회
      **/
     @GetMapping
-    public ResponseEntity<Page<PostResponse>> getPosts(@RequestParam(defaultValue = "0") int page) {
+    public ResponseEntity<PostListResponse> getPosts(@RequestParam(defaultValue = "0") int page) {
         Pageable pageable = PageRequest.of(page, 10, Sort.by("createdAt").descending());
         return ResponseEntity.ok(postService.getPosts(pageable));
     }

--- a/src/main/java/com/example/newsfeedproject/post/controller/PostController.java
+++ b/src/main/java/com/example/newsfeedproject/post/controller/PostController.java
@@ -6,6 +6,10 @@ import com.example.newsfeedproject.post.dto.UpdatePostContentRequest;
 import com.example.newsfeedproject.post.service.PostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -24,6 +28,15 @@ public class PostController {
     public ResponseEntity<PostResponse> createPost(@Valid @RequestBody PostRequest postRequest) {
         PostResponse postResponse = postService.createPost(postRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(postResponse);
+    }
+
+    /**
+     * 전체 게시물 조회
+     **/
+    @GetMapping
+    public ResponseEntity<Page<PostResponse>> getPosts(@RequestParam(defaultValue = "0") int page) {
+        Pageable pageable = PageRequest.of(page, 10, Sort.by("createdAt").descending());
+        return ResponseEntity.ok(postService.getPosts(pageable));
     }
 
     /**

--- a/src/main/java/com/example/newsfeedproject/post/dto/PostListResponse.java
+++ b/src/main/java/com/example/newsfeedproject/post/dto/PostListResponse.java
@@ -1,0 +1,11 @@
+package com.example.newsfeedproject.post.dto;
+
+import java.util.List;
+
+public record PostListResponse(
+        List<PostResponse> posts,
+        int page,
+        int totalPages,
+        long totalElements
+) {
+}

--- a/src/main/java/com/example/newsfeedproject/post/service/PostService.java
+++ b/src/main/java/com/example/newsfeedproject/post/service/PostService.java
@@ -1,6 +1,7 @@
 package com.example.newsfeedproject.post.service;
 
 import com.example.newsfeedproject.mapper.PostMapper;
+import com.example.newsfeedproject.post.dto.PostListResponse;
 import com.example.newsfeedproject.post.dto.PostRequest;
 import com.example.newsfeedproject.post.dto.PostResponse;
 import com.example.newsfeedproject.post.dto.UpdatePostContentRequest;
@@ -14,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.data.domain.Page;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -30,9 +33,14 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public Page<PostResponse> getPosts(Pageable pageable) {
-        return postRepository.findAll(pageable)
-                .map(postMapper::toResponse);
+    public PostListResponse getPosts(Pageable pageable) {
+        Page<Post> postPage = postRepository.findAll(pageable);
+        List<PostResponse> postResponses = postMapper.toListResponse(postPage);
+        return new PostListResponse(
+                postResponses,
+                postPage.getSize(),
+                postPage.getNumber(),
+                postPage.getTotalElements());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/newsfeedproject/post/service/PostService.java
+++ b/src/main/java/com/example/newsfeedproject/post/service/PostService.java
@@ -7,10 +7,13 @@ import com.example.newsfeedproject.post.dto.UpdatePostContentRequest;
 import com.example.newsfeedproject.post.entity.Post;
 import com.example.newsfeedproject.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.data.domain.Page;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +27,12 @@ public class PostService {
         Post post = postMapper.toEntity(postRequest);
         postRepository.save(post);
         return postMapper.toResponse(post);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PostResponse> getPosts(Pageable pageable) {
+        return postRepository.findAll(pageable)
+                .map(postMapper::toResponse);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 📝 작업 내용
- 뉴스피드 전체 조회 게시물 조회 기능입니다.
- 요구사항에 따라, 페이지네이션 크기는 10 고정입니다.
- size 파라미터가 불필요하여 API 경로 및 API 명세서를 수정하였습니다.

<!---- 스크린샷 (선택) -->

## 🔗 연관된 이슈
Related to: #27

<!---- 리뷰 요구사항 (선택) -->

<!---- 현재 버그 (선택) -->

## ✅ PR 유형

- [x] 새로운 기능 추가