### PR TITLE
전역 @Valid 예외 처리 기능 추가

### DIFF
--- a/src/main/java/com/example/newsfeedproject/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/newsfeedproject/common/exception/ErrorCode.java
@@ -22,7 +22,9 @@ public enum ErrorCode {
     IS_NOT_FOLLOWING("FOLL-003", "팔로우 관계가 아닙니다.", HttpStatus.BAD_REQUEST),
 
     BOOKMARK_ALREADY_EXISTS("BMK-001", "이미 북마크한 게시물입니다.", HttpStatus.BAD_REQUEST),
-    BOOKMARK_NOT_FOUND("BMK-002", "해당 게시물에 대한 북마크가 존재하지 않습니다.", HttpStatus.NOT_FOUND);
+    BOOKMARK_NOT_FOUND("BMK-002", "해당 게시물에 대한 북마크가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+
+    INVALID_INPUT_VALUE("VAL-001", "잘못된 입력값 입니다." , HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/example/newsfeedproject/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/newsfeedproject/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.example.newsfeedproject.common.exception;
 
 import com.example.newsfeedproject.common.dto.GlobalApiResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -13,6 +14,19 @@ public class GlobalExceptionHandler {
 
         ErrorCode errorCode = e.getErrorCode();
         GlobalApiResponse response = new GlobalApiResponse(errorCode.getCode(), errorCode.getMessage());
+
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<GlobalApiResponse> ValidationExceptionHandler(MethodArgumentNotValidException e) {
+
+        String errorMessage = e.getBindingResult()
+                .getAllErrors()
+                .get(0)
+                .getDefaultMessage();
+        ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+        GlobalApiResponse response = new GlobalApiResponse(errorCode.getCode(), errorMessage);
 
         return new ResponseEntity<>(response, errorCode.getHttpStatus());
     }


### PR DESCRIPTION
## 📝 작업 내용
- `MethodArgumentNotValidException` 발생 시 `@RestControllerAdvice`에서 예외를 가로채어 처리
- `BindingResult`에서 유효성 검증 실패 메시지를 추출하여 `GlobalApiResponse` 형태로 변환
- `VAL-001` 에러 코드 추가

<!---- 스크린샷 (선택) -->

## 🔗 연관된 이슈
Related to: #60 

<!---- 리뷰 요구사항 (선택) -->

<!---- 현재 버그 (선택) -->

## ✅ PR 유형

- [x] 새로운 기능 추가
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 그 외