### PR TITLE
1차 테스트 및 버그 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,13 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
     // MapStruct
+    // 주의 -> Lombok 보다 반드시 뒤에 작성
+    // Lombok 보다 앞에 있는 경우, Mapper 클래스에서 Lombok 어노테이션보다 먼저 수행되는 문제 발생 (Getter이 적용되지 않음)
     implementation 'org.mapstruct:mapstruct:1.4.2.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'
 
@@ -46,8 +52,6 @@ dependencies {
     // BCrypt
     implementation 'at.favre.lib:bcrypt:0.10.2'
 
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/example/newsfeedproject/common/annoation/ValidPassword.java
+++ b/src/main/java/com/example/newsfeedproject/common/annoation/ValidPassword.java
@@ -13,7 +13,7 @@ import java.lang.annotation.*;
  */
 @Documented
 @Constraint(validatedBy = PasswordValidator.class)
-@Target({ElementType.FIELD})
+@Target({ElementType.FIELD, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ValidPassword {
 

--- a/src/main/java/com/example/newsfeedproject/common/annoation/ValidPassword.java
+++ b/src/main/java/com/example/newsfeedproject/common/annoation/ValidPassword.java
@@ -13,7 +13,7 @@ import java.lang.annotation.*;
  */
 @Documented
 @Constraint(validatedBy = PasswordValidator.class)
-@Target({ElementType.FIELD, ElementType.METHOD})
+@Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ValidPassword {
 

--- a/src/main/java/com/example/newsfeedproject/common/config/WebConfig.java
+++ b/src/main/java/com/example/newsfeedproject/common/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.example.newsfeedproject.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final UserHandlerArgumentResolver userHandlerArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+
+        resolvers.add(userHandlerArgumentResolver);
+    }
+}

--- a/src/main/java/com/example/newsfeedproject/post/controller/PostController.java
+++ b/src/main/java/com/example/newsfeedproject/post/controller/PostController.java
@@ -35,32 +35,6 @@ public class PostController {
     }
 
     /**
-     * 전체 게시물 조회
-     * 생성일 기준 최신순
-     **/
-    @GetMapping
-    public ResponseEntity<PostListResponse> getPostsOrderByCreatedAt(@RequestParam(defaultValue = "0") int page) {
-
-        Pageable pageable = PageRequest.of(page, 10, Sort.by("createdAt").descending());
-        PostListResponse postListResponse = postService.getPosts(pageable);
-
-        return ResponseEntity.ok(postListResponse);
-    }
-
-    /**
-     * 전체 게시물 조회
-     * 수정일 기준 최신순
-     **/
-    @GetMapping
-    public ResponseEntity<PostListResponse> getPostsOrderByModifiedAt(@RequestParam(defaultValue = "0") int page) {
-
-        Pageable pageable = PageRequest.of(page, 10, Sort.by("modifiedAt").descending());
-        PostListResponse postListResponse = postService.getPosts(pageable);
-
-        return ResponseEntity.ok(postListResponse);
-    }
-
-    /**
      * 단건 게시물 조회
      **/
     @GetMapping("/{postId}")
@@ -72,18 +46,23 @@ public class PostController {
     }
 
     /**
-     * 기간별 게시물 조회
-     * 생성일 기준 최신순
+     * 전체 또는 기간별 게시물 조회
+     * 수정일 기준 최신순
      **/
     @GetMapping
-    public ResponseEntity<PostListResponse> getPostsByPeriod(@RequestParam LocalDateTime startDate,
-                                                             @RequestParam LocalDateTime endDate,
+    public ResponseEntity<PostListResponse> getPostsByPeriod(@RequestParam(required = false) LocalDateTime startDate,
+                                                             @RequestParam(required = false) LocalDateTime endDate,
                                                              @RequestParam(defaultValue = "0") int page) {
 
         Pageable pageable = PageRequest.of(page, 10, Sort.by("createdAt").descending());
-        PostListResponse postListResponseByPeriod = postService.getPostsByPeriod(startDate, endDate, pageable);
+        PostListResponse postListResponse;
 
-        return ResponseEntity.ok(postListResponseByPeriod);
+        if (startDate == null && endDate == null)
+            postListResponse = postService.getPosts(pageable);
+        else
+            postListResponse = postService.getPostsByPeriod(startDate, endDate, pageable);
+
+        return ResponseEntity.ok(postListResponse);
     }
 
     /**

--- a/src/main/java/com/example/newsfeedproject/post/entity/Post.java
+++ b/src/main/java/com/example/newsfeedproject/post/entity/Post.java
@@ -3,6 +3,7 @@ package com.example.newsfeedproject.post.entity;
 import com.example.newsfeedproject.common.entity.BaseEntity;
 import com.example.newsfeedproject.user.entity.User;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,6 +25,7 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Builder
     public Post(String title, String content, User user) {
         this.title = title;
         this.content = content;

--- a/src/main/java/com/example/newsfeedproject/user/entity/User.java
+++ b/src/main/java/com/example/newsfeedproject/user/entity/User.java
@@ -2,6 +2,7 @@ package com.example.newsfeedproject.user.entity;
 
 import com.example.newsfeedproject.common.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,13 +28,13 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private boolean isUsable = true;
 
+    @Builder
     public User(String name, String email, Integer age, String password) {
 
         this.name = name;
         this.email = email;
         this.age = age;
         this.password = password;
-        this.isUsable = true;
     }
 
     public void updateUserInfo(String name, Integer age) {

--- a/src/test/java/com/example/newsfeedproject/NewsfeedProjectApplicationTests.java
+++ b/src/test/java/com/example/newsfeedproject/NewsfeedProjectApplicationTests.java
@@ -1,5 +1,6 @@
 package com.example.newsfeedproject;
 
+import com.example.newsfeedproject.post.dto.PostRequest;
 import com.example.newsfeedproject.user.dto.SignupRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -9,7 +10,6 @@ import org.junit.jupiter.api.extension.MediaType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -45,20 +45,18 @@ class NewsfeedProjectApplicationTests {
     }
 
     @Test
-    @DisplayName("UserController -> getUserInfo 테스트")
-    void userControllerGetUserInfo () throws Exception {
+    @DisplayName("PostController -> createPost 테스트")
+    void postControllerCreatePost () throws Exception {
 
-        String path = "/users/profile";
+        String path = "/posts";
+        PostRequest postRequest = new PostRequest("제목", "내용");
 
-        MockHttpSession session = new MockHttpSession();
-        session.setAttribute("LOGIN_USER", 1L);
-
-        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get(path)
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.post(path)
                 .contentType(String.valueOf(MediaType.APPLICATION_JSON))
-                .session(session);
+                .content(objectMapper.writeValueAsString(postRequest));
 
         mvc.perform(requestBuilder)
-                .andExpect(status().is2xxSuccessful())
+                .andExpect(status().isCreated())
                 .andDo(print());
     }
 }

--- a/src/test/java/com/example/newsfeedproject/NewsfeedProjectApplicationTests.java
+++ b/src/test/java/com/example/newsfeedproject/NewsfeedProjectApplicationTests.java
@@ -9,10 +9,10 @@ import org.junit.jupiter.api.extension.MediaType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.transaction.annotation.Transactional;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -28,19 +28,37 @@ class NewsfeedProjectApplicationTests {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    @Transactional
+    // @Transactional // 만약 주석처리 할 경우 데이터가 DB에 저장됨
     @DisplayName("AuthController -> signup 테스트")
     void authControllerSignup () throws Exception {
 
         String path = "/auth/signup";
-        SignupRequest signupRequest = new SignupRequest("name", "abcd@gmail.com", 123, "password");
+        SignupRequest signupRequest = new SignupRequest("name", "abcd@gmail.com", 60, "111aaaAAA!!!");
 
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.post(path)
-                        .contentType(String.valueOf(MediaType.APPLICATION_JSON))
-                                .content(objectMapper.writeValueAsString(signupRequest));
+                .contentType(String.valueOf(MediaType.APPLICATION_JSON))
+                .content(objectMapper.writeValueAsString(signupRequest));
 
         mvc.perform(requestBuilder)
                 .andExpect(status().isCreated())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("UserController -> getUserInfo 테스트")
+    void userControllerGetUserInfo () throws Exception {
+
+        String path = "/users/profile";
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("LOGIN_USER", 1L);
+
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get(path)
+                .contentType(String.valueOf(MediaType.APPLICATION_JSON))
+                .session(session);
+
+        mvc.perform(requestBuilder)
+                .andExpect(status().is2xxSuccessful())
                 .andDo(print());
     }
 }

--- a/src/test/java/com/example/newsfeedproject/UserTests.java
+++ b/src/test/java/com/example/newsfeedproject/UserTests.java
@@ -1,0 +1,58 @@
+package com.example.newsfeedproject;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class UserTests {
+
+    @Autowired
+    MockMvc mvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("UserController -> getUserInfo 테스트")
+    void userControllerGetUserInfoByUserSession () throws Exception {
+
+        String path = "/users/profile";
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("LOGIN_USER", 3L);
+
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get(path)
+                .contentType(String.valueOf(MediaType.APPLICATION_JSON))
+                .session(session);
+
+        mvc.perform(requestBuilder)
+                .andExpect(status().is2xxSuccessful())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("UserController -> getUserInfo 테스트")
+    void userControllerGetUserInfoByUserId () throws Exception {
+
+        String path = "/users/{userId}";
+
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get(path, 3L)
+                .contentType(String.valueOf(MediaType.APPLICATION_JSON));
+
+        mvc.perform(requestBuilder)
+                .andExpect(status().is2xxSuccessful())
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
- Mapping 오류 수정
  - Entity 생성자에 `@Builder`를 부착합니다.
  - Lombok보다 먼저 컴파일할 경우 Lombok의 `@Getter` 어노테이션이 작동되지 않아 build.gradle의 dependencies에서 종속성 순서를 해결합니다.
- CustomValidation 오류 수정
  - `ValidPassword.java`의 `@Target`에 `ElementType.METHOD`를 추가합니다.
- LoginUserResolver 오류 수정
  - `@Configuration` 클래스 WebConfig를 추가합니다.
  -  `WebMvcConfigure`을 상속받은 뒤, `addArgumentResolvers`를 오버라이드하여 Resolver를 등록합니다.
- PostController의 `@GetMapping` 중복
  - 전체 게시물 조회, 기간별 게시물 조회의 URI 및 메서드가 중복이기 때문에 하나로 합칩니다.
  - startDate, endDate의 required를 false로 설정하여 두 값이 없으면 전체, 있으면 기간별 조회로 수정합니다.
- Test 코드 추가
  - DB에 데이터를 직접 추가할 수 있는 코드를 작성합니다.
  - API를 테스트하는 코드를 작성합니다.
- AuthController 리팩토링
  - `@RequestBody` 뒤에 `@Valid`를 작성합니다.

## 🔗 연관된 이슈
Related to: #55 #62 

## ✅ PR 유형

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 버그 수정