### PR TITLE
feat: 댓글 기능(CRUD) 구현

### DIFF
--- a/src/main/java/com/example/newsfeedproject/comment/controller/CommentController.java
+++ b/src/main/java/com/example/newsfeedproject/comment/controller/CommentController.java
@@ -1,0 +1,30 @@
+package com.example.newsfeedproject.comment.controller;
+
+import com.example.newsfeedproject.comment.dto.CommentCreateResponse;
+import com.example.newsfeedproject.comment.dto.CommentRequest;
+import com.example.newsfeedproject.comment.service.CommentService;
+import com.example.newsfeedproject.common.annoation.LoginUserResolver;
+import com.example.newsfeedproject.user.entity.User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/posts/{postId}/comments")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    public ResponseEntity<CommentCreateResponse> createComment(@PathVariable Long postId,
+                                                               @RequestBody @Valid CommentRequest commentRequest,
+                                                               @LoginUserResolver User user) {
+
+        CommentCreateResponse commentCreateResponse = commentService.createComment(postId, commentRequest, user);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(commentCreateResponse);
+    }
+}

--- a/src/main/java/com/example/newsfeedproject/comment/controller/CommentController.java
+++ b/src/main/java/com/example/newsfeedproject/comment/controller/CommentController.java
@@ -3,6 +3,7 @@ package com.example.newsfeedproject.comment.controller;
 import com.example.newsfeedproject.comment.dto.CommentCreateResponse;
 import com.example.newsfeedproject.comment.dto.CommentListResponse;
 import com.example.newsfeedproject.comment.dto.CommentRequest;
+import com.example.newsfeedproject.comment.dto.CommentUpdateResponse;
 import com.example.newsfeedproject.comment.service.CommentService;
 import com.example.newsfeedproject.common.annoation.LoginUserResolver;
 import com.example.newsfeedproject.user.entity.User;
@@ -21,6 +22,7 @@ public class CommentController {
 
     private final CommentService commentService;
 
+    // 댓글 생성 기능
     @PostMapping
     public ResponseEntity<CommentCreateResponse> createComment(@PathVariable Long postId,
                                                                @RequestBody @Valid CommentRequest commentRequest,
@@ -31,11 +33,36 @@ public class CommentController {
         return ResponseEntity.status(HttpStatus.CREATED).body(commentCreateResponse);
     }
 
+    // 댓글 조회 기능
     @GetMapping
     public ResponseEntity<List<CommentListResponse>> getComments(@PathVariable Long postId) {
 
         List<CommentListResponse> commentListResponse = commentService.getComments(postId);
 
         return ResponseEntity.ok(commentListResponse);
+    }
+
+    // 댓글 수정 기능
+    @PatchMapping("/{commentId}")
+    public ResponseEntity<CommentUpdateResponse> updateComment(@PathVariable Long postId,
+                                                               @PathVariable Long commentId,
+                                                               @RequestBody @Valid CommentRequest commentRequest,
+                                                               @LoginUserResolver User user) {
+
+        CommentUpdateResponse commentUpdateResponse = commentService.updateComment(commentId, commentRequest, user);
+
+        return ResponseEntity.ok(commentUpdateResponse);
+    }
+
+    // 댓글 삭제 기능
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<String> deleteComment(@PathVariable Long postId,
+                                                @PathVariable Long commentId,
+                                                @LoginUserResolver User user) {
+
+        commentService.deleteComment(commentId, user);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body("댓글이 삭제되었습니다.");
+
     }
 }

--- a/src/main/java/com/example/newsfeedproject/comment/controller/CommentController.java
+++ b/src/main/java/com/example/newsfeedproject/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.example.newsfeedproject.comment.controller;
 
 import com.example.newsfeedproject.comment.dto.CommentCreateResponse;
+import com.example.newsfeedproject.comment.dto.CommentListResponse;
 import com.example.newsfeedproject.comment.dto.CommentRequest;
 import com.example.newsfeedproject.comment.service.CommentService;
 import com.example.newsfeedproject.common.annoation.LoginUserResolver;
@@ -10,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,5 +29,13 @@ public class CommentController {
         CommentCreateResponse commentCreateResponse = commentService.createComment(postId, commentRequest, user);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(commentCreateResponse);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CommentListResponse>> getComments(@PathVariable Long postId) {
+
+        List<CommentListResponse> commentListResponse = commentService.getComments(postId);
+
+        return ResponseEntity.ok(commentListResponse);
     }
 }

--- a/src/main/java/com/example/newsfeedproject/comment/dto/CommentCreateResponse.java
+++ b/src/main/java/com/example/newsfeedproject/comment/dto/CommentCreateResponse.java
@@ -1,0 +1,11 @@
+package com.example.newsfeedproject.comment.dto;
+
+import java.time.LocalDateTime;
+
+public record CommentCreateResponse(
+
+        String content,
+        Long userId,
+        String username,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/example/newsfeedproject/comment/dto/CommentListResponse.java
+++ b/src/main/java/com/example/newsfeedproject/comment/dto/CommentListResponse.java
@@ -1,0 +1,7 @@
+package com.example.newsfeedproject.comment.dto;
+
+public record CommentListResponse(
+        Long userId,
+        String username,
+        String content
+) {}

--- a/src/main/java/com/example/newsfeedproject/comment/dto/CommentListResponse.java
+++ b/src/main/java/com/example/newsfeedproject/comment/dto/CommentListResponse.java
@@ -1,6 +1,7 @@
 package com.example.newsfeedproject.comment.dto;
 
 public record CommentListResponse(
+
         Long userId,
         String username,
         String content

--- a/src/main/java/com/example/newsfeedproject/comment/dto/CommentRequest.java
+++ b/src/main/java/com/example/newsfeedproject/comment/dto/CommentRequest.java
@@ -1,9 +1,9 @@
-package com.example.newsfeedproject.comment.dto;
+        package com.example.newsfeedproject.comment.dto;
 
-import jakarta.validation.constraints.NotBlank;
+        import jakarta.validation.constraints.NotBlank;
 
-public record CommentRequest(
+        public record CommentRequest(
 
-        @NotBlank(message = "댓글 내용은 필수입니다.")
-        String content
-) {}
+                @NotBlank(message = "댓글 내용은 필수입니다.")
+                String content
+        ) {}

--- a/src/main/java/com/example/newsfeedproject/comment/dto/CommentRequest.java
+++ b/src/main/java/com/example/newsfeedproject/comment/dto/CommentRequest.java
@@ -1,0 +1,9 @@
+package com.example.newsfeedproject.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CommentRequest(
+
+        @NotBlank(message = "댓글 내용은 필수입니다.")
+        String content
+) {}

--- a/src/main/java/com/example/newsfeedproject/comment/dto/CommentUpdateResponse.java
+++ b/src/main/java/com/example/newsfeedproject/comment/dto/CommentUpdateResponse.java
@@ -1,0 +1,6 @@
+package com.example.newsfeedproject.comment.dto;
+
+public record CommentUpdateResponse(
+
+        String content
+) {}

--- a/src/main/java/com/example/newsfeedproject/comment/entity/Comment.java
+++ b/src/main/java/com/example/newsfeedproject/comment/entity/Comment.java
@@ -1,0 +1,38 @@
+package com.example.newsfeedproject.comment.entity;
+
+import com.example.newsfeedproject.common.entity.BaseEntity;
+import com.example.newsfeedproject.post.entity.Post;
+import com.example.newsfeedproject.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Comment extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public Comment(String content, Post post, User user) {
+        this.content = content;
+        this.post = post;
+        this.user = user;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/example/newsfeedproject/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/newsfeedproject/comment/repository/CommentRepository.java
@@ -1,0 +1,12 @@
+package com.example.newsfeedproject.comment.repository;
+
+import com.example.newsfeedproject.comment.entity.Comment;
+import com.example.newsfeedproject.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findAllByPostOrderByCreatedAtDesc(Post post);
+}

--- a/src/main/java/com/example/newsfeedproject/comment/service/CommentService.java
+++ b/src/main/java/com/example/newsfeedproject/comment/service/CommentService.java
@@ -34,6 +34,7 @@ public class CommentService {
                 () -> new BusinessException(ErrorCode.POST_NOT_FOUND));
 
         Comment comment = new Comment(request.content(), post, user);
+        commentRepository.save(comment);
 
         return commentMapper.toCreateResponse(comment);
     }
@@ -59,10 +60,10 @@ public class CommentService {
                 () -> new BusinessException(ErrorCode.COMMENT_NOT_FOUND));
 
         boolean isCommentAuthor = comment.getUser().getId().equals(user.getId());
-        boolean isPostAuthor = comment.getPost().getId().equals(user.getId());
+        boolean isPostAuthor = comment.getPost().getUser().getId().equals(user.getId());
 
         // 댓글 작성자도 아니고 게시글 작성자도 아니면 예외 발생
-        if (isCommentAuthor || isPostAuthor)
+        if (!isCommentAuthor && !isPostAuthor)
             throw new BusinessException(ErrorCode.FORBIDDEN_COMMENT);
 
         comment.updateContent(request.content());
@@ -77,10 +78,10 @@ public class CommentService {
                 () -> new BusinessException(ErrorCode.COMMENT_NOT_FOUND));
 
         boolean isCommentAuthor = comment.getUser().getId().equals(user.getId());
-        boolean isPostAuthor = comment.getPost().getId().equals(user.getId());
+        boolean isPostAuthor = comment.getPost().getUser().getId().equals(user.getId());
 
         // 댓글 작성자도 아니고 게시글 작성자도 아니면 예외 발생
-        if (isCommentAuthor || isPostAuthor)
+        if (!isCommentAuthor && !isPostAuthor)
             throw new BusinessException(ErrorCode.FORBIDDEN_COMMENT);
 
         commentRepository.delete(comment);

--- a/src/main/java/com/example/newsfeedproject/comment/service/CommentService.java
+++ b/src/main/java/com/example/newsfeedproject/comment/service/CommentService.java
@@ -3,6 +3,7 @@ package com.example.newsfeedproject.comment.service;
 import com.example.newsfeedproject.comment.dto.CommentCreateResponse;
 import com.example.newsfeedproject.comment.dto.CommentListResponse;
 import com.example.newsfeedproject.comment.dto.CommentRequest;
+import com.example.newsfeedproject.comment.dto.CommentUpdateResponse;
 import com.example.newsfeedproject.comment.entity.Comment;
 import com.example.newsfeedproject.comment.repository.CommentRepository;
 import com.example.newsfeedproject.common.exception.BusinessException;
@@ -49,5 +50,39 @@ public class CommentService {
                 .collect(Collectors.toList());
 
         return commentListResponse;
+    }
+
+    @Transactional
+    public CommentUpdateResponse updateComment(Long commentId, CommentRequest request, User user) {
+
+        Comment comment = commentRepository.findById(commentId).orElseThrow(
+                () -> new BusinessException(ErrorCode.COMMENT_NOT_FOUND));
+
+        boolean isCommentAuthor = comment.getUser().getId().equals(user.getId());
+        boolean isPostAuthor = comment.getPost().getId().equals(user.getId());
+
+        // 댓글 작성자도 아니고 게시글 작성자도 아니면 예외 발생
+        if (isCommentAuthor || isPostAuthor)
+            throw new BusinessException(ErrorCode.FORBIDDEN_COMMENT);
+
+        comment.updateContent(request.content());
+
+        return commentMapper.toUpdateResponse(comment);
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId, User user) {
+
+        Comment comment = commentRepository.findById(commentId).orElseThrow(
+                () -> new BusinessException(ErrorCode.COMMENT_NOT_FOUND));
+
+        boolean isCommentAuthor = comment.getUser().getId().equals(user.getId());
+        boolean isPostAuthor = comment.getPost().getId().equals(user.getId());
+
+        // 댓글 작성자도 아니고 게시글 작성자도 아니면 예외 발생
+        if (isCommentAuthor || isPostAuthor)
+            throw new BusinessException(ErrorCode.FORBIDDEN_COMMENT);
+
+        commentRepository.delete(comment);
     }
 }

--- a/src/main/java/com/example/newsfeedproject/comment/service/CommentService.java
+++ b/src/main/java/com/example/newsfeedproject/comment/service/CommentService.java
@@ -1,0 +1,35 @@
+package com.example.newsfeedproject.comment.service;
+
+import com.example.newsfeedproject.comment.dto.CommentCreateResponse;
+import com.example.newsfeedproject.comment.dto.CommentRequest;
+import com.example.newsfeedproject.comment.entity.Comment;
+import com.example.newsfeedproject.comment.repository.CommentRepository;
+import com.example.newsfeedproject.common.exception.BusinessException;
+import com.example.newsfeedproject.common.exception.ErrorCode;
+import com.example.newsfeedproject.mapper.CommentMapper;
+import com.example.newsfeedproject.post.entity.Post;
+import com.example.newsfeedproject.post.repository.PostRepository;
+import com.example.newsfeedproject.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final CommentMapper commentMapper;
+
+    @Transactional
+    public CommentCreateResponse createComment(Long postId, CommentRequest request, User user) {
+
+        Post post = postRepository.findById(postId).orElseThrow(
+                () -> new BusinessException(ErrorCode.POST_NOT_FOUND));
+
+        Comment comment = new Comment(request.content(), post, user);
+
+        return commentMapper.toCreateResponse(comment);
+    }
+}

--- a/src/main/java/com/example/newsfeedproject/comment/service/CommentService.java
+++ b/src/main/java/com/example/newsfeedproject/comment/service/CommentService.java
@@ -1,6 +1,7 @@
 package com.example.newsfeedproject.comment.service;
 
 import com.example.newsfeedproject.comment.dto.CommentCreateResponse;
+import com.example.newsfeedproject.comment.dto.CommentListResponse;
 import com.example.newsfeedproject.comment.dto.CommentRequest;
 import com.example.newsfeedproject.comment.entity.Comment;
 import com.example.newsfeedproject.comment.repository.CommentRepository;
@@ -13,6 +14,9 @@ import com.example.newsfeedproject.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,5 +35,19 @@ public class CommentService {
         Comment comment = new Comment(request.content(), post, user);
 
         return commentMapper.toCreateResponse(comment);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommentListResponse> getComments(Long postId) {
+
+        Post post = postRepository.findById(postId).orElseThrow(
+                () -> new BusinessException(ErrorCode.POST_NOT_FOUND));
+
+        List<Comment> comments = commentRepository.findAllByPostOrderByCreatedAtDesc(post);
+        List<CommentListResponse> commentListResponse = comments.stream()
+                .map(commentMapper::toListResponse)
+                .collect(Collectors.toList());
+
+        return commentListResponse;
     }
 }

--- a/src/main/java/com/example/newsfeedproject/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/newsfeedproject/common/exception/ErrorCode.java
@@ -24,7 +24,10 @@ public enum ErrorCode {
     BOOKMARK_ALREADY_EXISTS("BMK-001", "이미 북마크한 게시물입니다.", HttpStatus.BAD_REQUEST),
     BOOKMARK_NOT_FOUND("BMK-002", "해당 게시물에 대한 북마크가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
 
-    INVALID_INPUT_VALUE("VAL-001", "잘못된 입력값 입니다." , HttpStatus.BAD_REQUEST);
+    INVALID_INPUT_VALUE("VAL-001", "잘못된 입력값 입니다." , HttpStatus.BAD_REQUEST),
+
+    COMMENT_NOT_FOUND("CMT-001", "댓글이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
+    FORBIDDEN_COMMENT("CMT-002", "댓글 수정 또는 삭제 권한이 없습니다.", HttpStatus.FORBIDDEN);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/example/newsfeedproject/mapper/CommentMapper.java
+++ b/src/main/java/com/example/newsfeedproject/mapper/CommentMapper.java
@@ -1,0 +1,30 @@
+package com.example.newsfeedproject.mapper;
+
+import com.example.newsfeedproject.comment.dto.CommentCreateResponse;
+import com.example.newsfeedproject.comment.dto.CommentListResponse;
+import com.example.newsfeedproject.comment.dto.CommentUpdateResponse;
+import com.example.newsfeedproject.comment.entity.Comment;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * Comment 관련 매핑 처리를 위한 Mapper 클래스
+ */
+@Mapper(componentModel = "spring")
+public interface CommentMapper {
+
+    // Comment Entity -> CommentCreateResponse DTO
+    @Mapping(source = "user.id", target = "userId")
+    @Mapping(source = "user.name", target = "username")
+    CommentCreateResponse toCreateResponse(Comment comment);
+
+    // Comment Entity -> CommentUpdateResponse DTO
+    CommentUpdateResponse toUpdateResponse(Comment comment);
+
+    // Comment Entity -> CommentListResponse DTO
+    @Mapping(source = "user.id", target = "userId")
+    @Mapping(source = "user.name", target = "username")
+    CommentListResponse toListResponse(Comment comment);
+
+
+}


### PR DESCRIPTION
## 📝 작업 내용
- [ ] 댓글 기능 신규 구현 (CRUD)
  - Comment 엔티티, DTO(Request, Response) 리포지토리, 매퍼 생성
  - POST /posts/{postId}/comments: 댓글 작성
  - GET /posts/{postId}/comments: 게시물 댓글 목록 조회
  - PATCH /posts/{postId}/comments/{commentId}: 댓글 수정
  - DELETE /posts/{postId}/comments/{commentId}: 댓글 삭제

## 🔗 연관된 이슈
Related to: #54 

## ✅ PR 유형

- [x] 새로운 기능 추가
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 그 외