### PR TITLE
refactor: 엔티티 생성자 접근 제어 및 빌더 제거

### DIFF
--- a/src/main/java/com/example/newsfeedproject/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/example/newsfeedproject/domain/bookmark/entity/Bookmark.java
@@ -4,12 +4,13 @@ import com.example.newsfeedproject.common.entity.BaseEntity;
 import com.example.newsfeedproject.domain.post.entity.Post;
 import com.example.newsfeedproject.domain.user.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Bookmark extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/newsfeedproject/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/newsfeedproject/domain/comment/entity/Comment.java
@@ -4,12 +4,13 @@ import com.example.newsfeedproject.common.entity.BaseEntity;
 import com.example.newsfeedproject.domain.post.entity.Post;
 import com.example.newsfeedproject.domain.user.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/newsfeedproject/domain/follow/entity/Follow.java
+++ b/src/main/java/com/example/newsfeedproject/domain/follow/entity/Follow.java
@@ -3,12 +3,13 @@ package com.example.newsfeedproject.domain.follow.entity;
 import com.example.newsfeedproject.common.entity.BaseEntity;
 import com.example.newsfeedproject.domain.user.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "follow")
 public class Follow extends BaseEntity {
 

--- a/src/main/java/com/example/newsfeedproject/domain/like/entity/Like.java
+++ b/src/main/java/com/example/newsfeedproject/domain/like/entity/Like.java
@@ -4,12 +4,13 @@ import com.example.newsfeedproject.common.entity.BaseEntity;
 import com.example.newsfeedproject.domain.post.entity.Post;
 import com.example.newsfeedproject.domain.user.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 // DB 레벨에서의 유일성 강제
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"user_id","post_id"}))
 public class Like extends BaseEntity {

--- a/src/main/java/com/example/newsfeedproject/domain/post/entity/Post.java
+++ b/src/main/java/com/example/newsfeedproject/domain/post/entity/Post.java
@@ -4,7 +4,6 @@ import com.example.newsfeedproject.common.entity.BaseEntity;
 import com.example.newsfeedproject.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/example/newsfeedproject/domain/post/entity/Post.java
+++ b/src/main/java/com/example/newsfeedproject/domain/post/entity/Post.java
@@ -3,13 +3,14 @@ package com.example.newsfeedproject.domain.post.entity;
 import com.example.newsfeedproject.common.entity.BaseEntity;
 import com.example.newsfeedproject.domain.user.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,7 +32,6 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Builder
     public Post(String title, String content, User user) {
         this.title = title;
         this.content = content;

--- a/src/main/java/com/example/newsfeedproject/domain/user/entity/User.java
+++ b/src/main/java/com/example/newsfeedproject/domain/user/entity/User.java
@@ -3,7 +3,6 @@ package com.example.newsfeedproject.domain.user.entity;
 import com.example.newsfeedproject.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/example/newsfeedproject/domain/user/entity/User.java
+++ b/src/main/java/com/example/newsfeedproject/domain/user/entity/User.java
@@ -2,13 +2,14 @@ package com.example.newsfeedproject.domain.user.entity;
 
 import com.example.newsfeedproject.common.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,7 +29,6 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private boolean isUsable = true;
 
-    @Builder
     public User(String name, String email, Integer age, String password) {
 
         this.name = name;


### PR DESCRIPTION
## 📝 작업 내용
- [x] 엔티티 기본 생성자에 AccessLevel.PROTECTED 접근 제어를 추가
  - 적용 대상: User, Post, Comment, Bookmark, Follow, Like 엔티티
- [x] 엔티티 생성자에서 @Builder 어노테이션을 제거
  - 적용 대상: User, Post 엔티티
## 🔗 연관된 이슈
Related to: #66 

## ✅ PR 유형
- [x] 코드 리팩토링
