### PR TITLE
UpdateUserInfo 입력값 검증 로직 리팩토링

### DIFF
--- a/src/main/java/com/example/newsfeedproject/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/newsfeedproject/common/exception/ErrorCode.java
@@ -13,7 +13,6 @@ public enum ErrorCode {
 
     PASSWORD_INCORRECT("USR-001", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
     PASSWORD_NOT_AVAILABLE("USR-002", "새 비밀번호는 현재 비밀번호와 달라야 합니다.", HttpStatus.BAD_REQUEST),
-    REQUIRED_UPDATE_INFO("USR-003", "이름 또는 나이 중 하나는 반드시 입력되어야 합니다.", HttpStatus.BAD_REQUEST),
 
     POST_NOT_FOUND("POST-001", "존재하지 않는 게시물입니다.", HttpStatus.NOT_FOUND),
 

--- a/src/main/java/com/example/newsfeedproject/domain/user/dto/UpdateUserInfoRequest.java
+++ b/src/main/java/com/example/newsfeedproject/domain/user/dto/UpdateUserInfoRequest.java
@@ -1,5 +1,6 @@
 package com.example.newsfeedproject.domain.user.dto;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Size;
 
@@ -11,7 +12,9 @@ public record UpdateUserInfoRequest(
         @Max(value = 120, message = "나이는 최대 120세까지 입력 가능합니다.")
         Integer age
 ) {
-    public boolean isEmpty() {
-        return name == null && age == null;
+
+    @AssertTrue(message = "이름 또는 나이 중 하나는 반드시 입력해야 합니다.")
+    public boolean isValidInput() {
+        return name != null && age != null;
     }
 }

--- a/src/main/java/com/example/newsfeedproject/domain/user/entity/User.java
+++ b/src/main/java/com/example/newsfeedproject/domain/user/entity/User.java
@@ -30,7 +30,6 @@ public class User extends BaseEntity {
 
     @Builder
     public User(String name, String email, Integer age, String password) {
-
         this.name = name;
         this.email = email;
         this.age = age;
@@ -38,7 +37,6 @@ public class User extends BaseEntity {
     }
 
     public void updateUserInfo(String name, Integer age) {
-
         if (name != null)
             this.name = name;
 
@@ -47,12 +45,10 @@ public class User extends BaseEntity {
     }
 
     public void updatePassword(String password) {
-
         this.password = password;
     }
 
     public void markAsWithdrawn(){
-
         this.isUsable = false;
     }
 }

--- a/src/main/java/com/example/newsfeedproject/domain/user/service/UserService.java
+++ b/src/main/java/com/example/newsfeedproject/domain/user/service/UserService.java
@@ -32,9 +32,6 @@ public class UserService {
     @Transactional
     public UserResponse updateUserInfo(Long id, UpdateUserInfoRequest request) {
 
-        if (request.isEmpty())
-            throw new BusinessException(ErrorCode.REQUIRED_UPDATE_INFO);
-
         User targetUser = userRepository.findByIdOrElseThrow(id);
         targetUser.updateUserInfo(request.name(), request.age());
 


### PR DESCRIPTION
## 📝 작업 내용
- 서비스 계층에서 처리하던 유효성 검증 로직을 `@AssertTrue` 어노테이션으로 리팩토링
- 사용하지 않는 `ErrorCode` 및 서비스 로직 제거
- `User` 엔티티 줄바꿈 스타일을 다른 엔티티들과 통일하여 코드 일관성 확보

## 🔗 연관된 이슈
Related to: #67

## ✅ PR 유형
- [x] 코드 리팩토링
