### PR TITLE
fix: like compile

### DIFF
--- a/src/main/java/com/example/newsfeedproject/domain/like/entity/Like.java
+++ b/src/main/java/com/example/newsfeedproject/domain/like/entity/Like.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 // DB 레벨에서의 유일성 강제
-@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"user_id","post_id"}))
+@Table(name = "likes", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id","post_id"}))
 public class Like extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/newsfeedproject/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/example/newsfeedproject/domain/like/repository/LikeRepository.java
@@ -13,5 +13,5 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
     void deleteByUserIdAndPostId(Long userId, Long postId);
 
-    List<PostUserResponse> findByPostId(Long postId);
+    List<Like> findByPostId(Long postId);
 }

--- a/src/main/java/com/example/newsfeedproject/domain/like/service/LikeService.java
+++ b/src/main/java/com/example/newsfeedproject/domain/like/service/LikeService.java
@@ -98,10 +98,11 @@ public class LikeService {
 
         Post post = postRepository.findByIdOrElseThrow(postId);
 
-        List<PostUserResponse> likedUsers = likeRepository.findByPostId(postId).stream()
+        List<Like> likes = likeRepository.findByPostId(postId);
+        List<PostUserResponse> likedUsers = likes.stream()
                 .map(like -> new PostUserResponse(
-                        like.id(),
-                        like.name()
+                        like.getUser().getId(),
+                        like.getUser().getName()
                 ))
                 .toList();
 


### PR DESCRIPTION
## 📝 작업 내용
like 도메인의 컴파일 에러를 수정하였습니다.
- MySQL 예약으로 인한 likes 테이블 명 설정
- findByPostId 반환 타입 수정
- getLikeList 수정
<!---- 스크린샷 (선택) -->

## 🔗 연관된 이슈
Related to: #51

<!---- 리뷰 요구사항 (선택) -->

<!---- 현재 버그 (선택) -->

## ✅ PR 유형

- [x] 코드 리팩토링
- [x] 버그 수정