### PR TITLE
User DTO 필드 누락 및 검증 로직 수정

### DIFF
--- a/src/main/java/com/example/newsfeedproject/common/annotation/ValidPassword.java
+++ b/src/main/java/com/example/newsfeedproject/common/annotation/ValidPassword.java
@@ -13,7 +13,7 @@ import java.lang.annotation.*;
  */
 @Documented
 @Constraint(validatedBy = PasswordValidator.class)
-@Target({ElementType.METHOD})
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ValidPassword {
 

--- a/src/main/java/com/example/newsfeedproject/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/newsfeedproject/domain/auth/service/AuthService.java
@@ -25,7 +25,7 @@ public class AuthService {
 
         // 탈퇴한 유저의 이메일도 함께 처리
         if (userRepository.findByEmail(signupRequest.email()).isPresent())
-            throw new BusinessException(ErrorCode.PASSWORD_INCORRECT);
+            throw new BusinessException(ErrorCode.EMAIL_ALREADY_EXISTS);
 
         User user = userMapper.toEntity(signupRequest);
         String encodedPassword = passwordEncoder.encode(signupRequest.password());
@@ -40,8 +40,8 @@ public class AuthService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        if (!passwordEncoder.matches(user.getPassword(), deleteUserRequest.password()))
-            throw new BusinessException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        if (!passwordEncoder.matches(deleteUserRequest.password(), user.getPassword()))
+            throw new BusinessException(ErrorCode.PASSWORD_INCORRECT);
 
         // 유저 논리적 삭제
         user.markAsWithdrawn();

--- a/src/main/java/com/example/newsfeedproject/domain/like/dto/ListLikeResponse.java
+++ b/src/main/java/com/example/newsfeedproject/domain/like/dto/ListLikeResponse.java
@@ -1,11 +1,11 @@
 package com.example.newsfeedproject.domain.like.dto;
 
-import com.example.newsfeedproject.domain.user.dto.PostUserResponse;
+import com.example.newsfeedproject.domain.user.dto.AuthorResponse;
 
 import java.util.List;
 
 public record ListLikeResponse(
 
-        List<PostUserResponse> postUserResponseList,
+        List<AuthorResponse> authorList,
         Long totalLikes
 ) {}

--- a/src/main/java/com/example/newsfeedproject/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/example/newsfeedproject/domain/post/dto/PostResponse.java
@@ -1,6 +1,6 @@
 package com.example.newsfeedproject.domain.post.dto;
 
-import com.example.newsfeedproject.domain.user.dto.UserResponse;
+import com.example.newsfeedproject.domain.user.dto.AuthorResponse;
 
 import java.time.LocalDateTime;
 
@@ -9,8 +9,8 @@ public record PostResponse(
         Long id,
         String title,
         String content,
+        AuthorResponse author,
         Long likesCount,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt,
-        UserResponse userResponse
+        LocalDateTime updatedAt
 ) {}

--- a/src/main/java/com/example/newsfeedproject/domain/user/dto/AuthorResponse.java
+++ b/src/main/java/com/example/newsfeedproject/domain/user/dto/AuthorResponse.java
@@ -1,6 +1,6 @@
 package com.example.newsfeedproject.domain.user.dto;
 
-public record PostUserResponse(
+public record AuthorResponse(
 
         Long id,
         String name

--- a/src/main/java/com/example/newsfeedproject/domain/user/dto/UpdateUserInfoRequest.java
+++ b/src/main/java/com/example/newsfeedproject/domain/user/dto/UpdateUserInfoRequest.java
@@ -15,6 +15,6 @@ public record UpdateUserInfoRequest(
 
     @AssertTrue(message = "이름 또는 나이 중 하나는 반드시 입력해야 합니다.")
     public boolean isValidInput() {
-        return name != null && age != null;
+        return name != null || age != null;
     }
 }

--- a/src/main/java/com/example/newsfeedproject/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/example/newsfeedproject/domain/user/dto/UserResponse.java
@@ -1,11 +1,15 @@
 package com.example.newsfeedproject.domain.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.time.LocalDateTime;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record UserResponse(
         Long id,
         String name,
         String email,
+        Integer age,
         LocalDateTime createdAt,
         LocalDateTime modifiedAt
 ) {}


### PR DESCRIPTION
## 📝 작업 내용
UserResponseDTO 내부 age 필드 추가
PostUserResponse → AuthorResponse로 명확한 의미 전달을 위해 네이밍 변경
UpdateUserInfoRequest 내부 유효성 검증 로직 수정
`@ValidPassword` 커스텀 어노테이션 트러블슈팅 및 정상 작동 확인
AuthService 내부 `matches()` 순서와 ErrorCode 바뀐 부분 수정
PostResponse 응답 형식 및 명세 일치

<!---- 스크린샷 (선택) -->

## 🔗 연관된 이슈
Related to: #79 

<!---- 리뷰 요구사항 (선택) -->

<!---- 현재 버그 (선택) -->

## ✅ PR 유형
- [x] 코드 리팩토링
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)