### PR TITLE
refactor: Post 도메인 오류 수정 및 코드 개선

### DIFF
--- a/src/main/java/com/example/newsfeedproject/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/newsfeedproject/common/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     PASSWORD_NOT_AVAILABLE("USR-002", "새 비밀번호는 현재 비밀번호와 달라야 합니다.", HttpStatus.BAD_REQUEST),
 
     POST_NOT_FOUND("POST-001", "존재하지 않는 게시물입니다.", HttpStatus.NOT_FOUND),
+    FORBIDDEN_POST("POST-002", "작성자만 수정 또는 삭제할 수 있습니다.", HttpStatus.FORBIDDEN),
 
     CANNOT_FOLLOW_SELF("FOLL-001", "자기 자신을 팔로우할 수 없습니다.", HttpStatus.BAD_REQUEST),
     ALREADY_FOLLOWED("FOLL-002", "이미 팔로우 한 유저입니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/example/newsfeedproject/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/newsfeedproject/domain/post/controller/PostController.java
@@ -25,12 +25,12 @@ public class PostController {
 
     private final PostService postService;
 
-     // 뉴스피드 게시물 생성
+    // 뉴스피드 게시물 생성
     @PostMapping
-    public ResponseEntity<PostResponse> createPost(@RequestBody @Valid PostRequest postRequest,
+    public ResponseEntity<PostResponse> createPost(@RequestBody @Valid PostRequest request,
                                                    @LoginUserResolver User user) {
 
-        PostResponse postResponse = postService.createPost(postRequest, user);
+        PostResponse postResponse = postService.createPost(request, user);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(postResponse);
     }
@@ -60,14 +60,14 @@ public class PostController {
 
     // 단건 게시물 조회
     @GetMapping("/{postId}")
-    public ResponseEntity<PostResponse> getPost(@Valid @PathVariable Long postId) {
+    public ResponseEntity<PostResponse> getPost(@PathVariable Long postId) {
 
         PostResponse postResponseById = postService.getPostById(postId);
 
         return ResponseEntity.ok(postResponseById);
     }
 
-     // 기간별 게시물 조회 (생성일 기준 최신순)
+    // 기간별 게시물 조회 (생성일 기준 최신순)
     @GetMapping("/search/period")
     public ResponseEntity<PostListResponse> getPostsByPeriod(@RequestParam LocalDateTime startDate,
                                                              @RequestParam LocalDateTime endDate,
@@ -79,22 +79,24 @@ public class PostController {
         return ResponseEntity.ok(postListResponseByPeriod);
     }
 
-     // 게시물 내용 수정
+    // 게시물 내용 수정
     @PatchMapping("/{postId}")
-    public ResponseEntity<PostResponse> updatePostContent(@PathVariable Long postId,
-                                                          @Valid @RequestBody UpdatePostContentRequest updatePostContentRequest) {
+    public ResponseEntity<PostResponse> updatePostContent(@LoginUserResolver User user,
+                                                          @PathVariable Long postId,
+                                                          @Valid @RequestBody UpdatePostContentRequest request) {
 
-        PostResponse updatePostContentResponse = postService.updatePostContent(postId, updatePostContentRequest);
+        PostResponse updatePostContentResponse = postService.updatePostContent(user, postId, request);
 
         return ResponseEntity.ok(updatePostContentResponse);
     }
 
-     // 게시물 삭제
+    // 게시물 삭제
     @DeleteMapping("/{postId}")
-    public ResponseEntity<String> deletePost(@PathVariable Long postId) {
+    public ResponseEntity<Void> deletePost(@LoginUserResolver User user,
+                                           @PathVariable Long postId) {
 
-        postService.deletePostById(postId);
+        postService.deletePostById(user, postId);
 
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).body("게시물이 삭제되었습니다.");
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/newsfeedproject/domain/post/dto/PostListResponse.java
+++ b/src/main/java/com/example/newsfeedproject/domain/post/dto/PostListResponse.java
@@ -8,5 +8,4 @@ public record PostListResponse(
         int page,
         int totalPages,
         long totalElements
-) {
-}
+) {}

--- a/src/main/java/com/example/newsfeedproject/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/example/newsfeedproject/domain/post/dto/PostRequest.java
@@ -5,8 +5,8 @@ import jakarta.validation.constraints.Size;
 
 public record PostRequest(
 
-    @NotBlank(message = "유저명은 필수 입력사항입니다.")
-    @Size(max = 20, message = "유저명은 최대 20자까지 입력이 가능합니다.")
+    @NotBlank(message = "제목은 필수 입력사항입니다.")
+    @Size(max = 20, message = "제목은 최대 20자까지 입력이 가능합니다.")
     String title,
 
     @NotBlank(message = "내용은 필수 입력사항입니다.")

--- a/src/main/java/com/example/newsfeedproject/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/example/newsfeedproject/domain/post/dto/PostResponse.java
@@ -1,9 +1,11 @@
 package com.example.newsfeedproject.domain.post.dto;
 
 import com.example.newsfeedproject.domain.user.dto.AuthorResponse;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.time.LocalDateTime;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record PostResponse(
 
         Long id,
@@ -12,5 +14,5 @@ public record PostResponse(
         AuthorResponse author,
         Long likesCount,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        LocalDateTime modifiedAt
 ) {}

--- a/src/main/java/com/example/newsfeedproject/domain/post/mapper/PostMapper.java
+++ b/src/main/java/com/example/newsfeedproject/domain/post/mapper/PostMapper.java
@@ -3,9 +3,11 @@ package com.example.newsfeedproject.domain.post.mapper;
 import com.example.newsfeedproject.domain.post.dto.PostRequest;
 import com.example.newsfeedproject.domain.post.dto.PostResponse;
 import com.example.newsfeedproject.domain.post.entity.Post;
+import com.example.newsfeedproject.domain.user.dto.AuthorResponse;
 import com.example.newsfeedproject.domain.user.entity.User;
 import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.springframework.data.domain.Page;
 
@@ -20,12 +22,19 @@ import java.util.List;
 @Mapper(componentModel = "spring")
 public interface PostMapper {
 
-    // PostRequest DTO -> Post 엔티티
+    // PostRequest DTO -> Post Entity
     Post toEntity(PostRequest postRequest, User user);
 
     // Post Entity -> PostResponse DTO
+    @Mapping(source = "user", target = "author", qualifiedByName = "toAuthorResponse")
     @Named("toResponse(Post)")
     PostResponse toResponse(Post post);
+
+    // User Entity -> AuthorResponse DTO
+    @Named("toAuthorResponse")
+    default AuthorResponse toAuthorResponse(User user) {
+        return new AuthorResponse(user);
+    }
 
     // Page<Post> -> List<PostResponse>
     @IterableMapping(qualifiedByName = "toResponse(Post)")

--- a/src/main/java/com/example/newsfeedproject/domain/user/dto/AuthorResponse.java
+++ b/src/main/java/com/example/newsfeedproject/domain/user/dto/AuthorResponse.java
@@ -1,7 +1,13 @@
 package com.example.newsfeedproject.domain.user.dto;
 
+import com.example.newsfeedproject.domain.user.entity.User;
+
 public record AuthorResponse(
 
         Long id,
         String name
-) {}
+) {
+    public AuthorResponse(User user) {
+        this(user.getId(), user.getName());
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
PostResponse DTO의 author, updatedAt 필드 null 반환 -> PostMapper 메서드 추가 및modifiedAt로 수정
유저 정보 수정 및 삭제 시 본인 확인 로직 누락 -> 로그인된 User 객체 받아와서 확인 로직 작성-> 중복 로직 메서드 분리 및 에러코드 추가
204 No Content 응답 시 바디 불필요 -> 바디 삭제
PostListResponse DTO 필드 형식에 맞게 서비스 반환 메서드 수정 필요 -> 수정 완료

<!---- 스크린샷 (선택) -->

## 🔗 연관된 이슈
Related to: #89

<!---- 리뷰 요구사항 (선택) -->

<!---- 현재 버그 (선택) -->

## ✅ PR 유형
- [x] 코드 리팩토링