### PR TITLE
fix: 기간별 게시물 조회 버그 수정

### DIFF
--- a/src/main/java/com/example/newsfeedproject/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/newsfeedproject/domain/post/controller/PostController.java
@@ -12,11 +12,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @RestController
 @RequiredArgsConstructor
@@ -69,12 +72,16 @@ public class PostController {
 
     // 기간별 게시물 조회 (생성일 기준 최신순)
     @GetMapping("/search/period")
-    public ResponseEntity<PostListResponse> getPostsByPeriod(@RequestParam LocalDateTime startDate,
-                                                             @RequestParam LocalDateTime endDate,
+    public ResponseEntity<PostListResponse> getPostsByPeriod(@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+                                                             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
                                                              @RequestParam(defaultValue = "0") int page) {
 
+        // LocalDate를 LocalDateTime으로 변환
+        LocalDateTime startDateTime = startDate.atStartOfDay();
+        LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
+
         Pageable pageable = PageRequest.of(page, 10, Sort.by("createdAt").descending());
-        PostListResponse postListResponseByPeriod = postService.getPostsByPeriod(startDate, endDate, pageable);
+        PostListResponse postListResponseByPeriod = postService.getPostsByPeriod(startDateTime, endDateTime, pageable);
 
         return ResponseEntity.ok(postListResponseByPeriod);
     }


### PR DESCRIPTION
## 📝 작업 내용
- [x] PostController의 getPostsByPeriod 메소드 파라미터 타입을 LocalDateTime -> LocalDate로 변경

- [x] 날짜 입력해도 검색 종료일(endDate)이 해당 날짜 시작 시간(00:00:00)으로 변경되어 해결 안되던 문제 수정

## 🔗 연관된 이슈
Related to: #87 

## ✅ PR 유형

- [x] 버그 수정