### PR TITLE
API 데이터 반환시 공통적인 형식 적용

### DIFF
--- a/src/main/java/com/example/newsfeedproject/common/dto/GlobalApiResponse.java
+++ b/src/main/java/com/example/newsfeedproject/common/dto/GlobalApiResponse.java
@@ -1,7 +1,12 @@
 package com.example.newsfeedproject.common.dto;
 
-public record GlobalApiResponse(
+import java.time.LocalDateTime;
 
-        String code,
-        String message
+public record GlobalApiResponse<T> (
+
+        String status,
+        String message,
+        T data,
+        LocalDateTime timestamp,
+        int code
 ) { }

--- a/src/main/java/com/example/newsfeedproject/common/dto/GlobalApiResponse.java
+++ b/src/main/java/com/example/newsfeedproject/common/dto/GlobalApiResponse.java
@@ -1,6 +1,7 @@
 package com.example.newsfeedproject.common.dto;
 
 import com.example.newsfeedproject.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
 
 import java.time.LocalDateTime;
 
@@ -12,6 +13,9 @@ public record GlobalApiResponse<T> (
         LocalDateTime timestamp,
         int code
 ) {
+    /**
+     * 오류 메시지를 반환
+     */
     public static <T> GlobalApiResponse<T> error(String message, ErrorCode errorCode) {
         return new GlobalApiResponse<>(
                 errorCode.getCode(),
@@ -21,4 +25,26 @@ public record GlobalApiResponse<T> (
                 errorCode.getHttpStatus().value()
         );
     }
+
+    /**
+     * 성공 메시지를 반환
+     * @param httpStatus HttpStatus
+     * @param message Success Message
+     * @param data Response Data
+     */
+    public static <T> GlobalApiResponse<T> success(HttpStatus httpStatus, String message, T data) {
+        return new GlobalApiResponse<>(
+                httpStatus.getReasonPhrase(),
+                message,
+                data,
+                LocalDateTime.now(),
+                httpStatus.value()
+        );
+    }
+
+    public static <T> GlobalApiResponse<T> ok(String message, T data) {
+        return GlobalApiResponse.success(HttpStatus.OK, message, data);
+    }
+
+
 }

--- a/src/main/java/com/example/newsfeedproject/common/dto/GlobalApiResponse.java
+++ b/src/main/java/com/example/newsfeedproject/common/dto/GlobalApiResponse.java
@@ -1,5 +1,7 @@
 package com.example.newsfeedproject.common.dto;
 
+import com.example.newsfeedproject.common.exception.ErrorCode;
+
 import java.time.LocalDateTime;
 
 public record GlobalApiResponse<T> (
@@ -9,4 +11,14 @@ public record GlobalApiResponse<T> (
         T data,
         LocalDateTime timestamp,
         int code
-) { }
+) {
+    public static <T> GlobalApiResponse<T> error(String message, ErrorCode errorCode) {
+        return new GlobalApiResponse<>(
+                errorCode.getCode(),
+                message,
+                null,
+                LocalDateTime.now(),
+                errorCode.getHttpStatus().value()
+        );
+    }
+}

--- a/src/main/java/com/example/newsfeedproject/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/newsfeedproject/common/exception/GlobalExceptionHandler.java
@@ -10,23 +10,23 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler
-    public ResponseEntity<GlobalApiResponse> businessExceptionHandler(BusinessException e) {
+    public ResponseEntity<GlobalApiResponse<?>> businessExceptionHandler(BusinessException e) {
 
         ErrorCode errorCode = e.getErrorCode();
-        GlobalApiResponse response = new GlobalApiResponse(errorCode.getCode(), errorCode.getMessage());
+        GlobalApiResponse<?> response = GlobalApiResponse.error(errorCode.getMessage(), errorCode);
 
         return new ResponseEntity<>(response, errorCode.getHttpStatus());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<GlobalApiResponse> ValidationExceptionHandler(MethodArgumentNotValidException e) {
+    public ResponseEntity<GlobalApiResponse<?>> ValidationExceptionHandler(MethodArgumentNotValidException e) {
 
         String errorMessage = e.getBindingResult()
                 .getAllErrors()
                 .get(0)
                 .getDefaultMessage();
         ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
-        GlobalApiResponse response = new GlobalApiResponse(errorCode.getCode(), errorMessage);
+        GlobalApiResponse<?> response = GlobalApiResponse.error(errorMessage, errorCode);
 
         return new ResponseEntity<>(response, errorCode.getHttpStatus());
     }

--- a/src/main/java/com/example/newsfeedproject/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/newsfeedproject/domain/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.example.newsfeedproject.domain.auth.controller;
 
 import com.example.newsfeedproject.common.annotation.LoginUserResolver;
+import com.example.newsfeedproject.common.dto.GlobalApiResponse;
 import com.example.newsfeedproject.domain.auth.service.AuthService;
 import com.example.newsfeedproject.domain.user.dto.DeleteUserRequest;
 import com.example.newsfeedproject.domain.user.dto.LoginRequest;
@@ -11,7 +12,6 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -22,28 +22,29 @@ public class AuthController {
 
     // 회원가입
     @PostMapping("/signup")
-    public ResponseEntity<String> signup(@Valid @RequestBody SignupRequest request) {
+    public GlobalApiResponse<?> signup(@Valid @RequestBody SignupRequest request) {
 
         authService.signup(request);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body("회원가입이 완료되었습니다.");
+        return GlobalApiResponse.success(HttpStatus.CREATED, "회원 가입이 완료되었습니다.", null);
     }
 
     // 로그인
     @PostMapping("/login")
-    public ResponseEntity<String> login(@Valid @RequestBody LoginRequest request,
-                                        HttpServletRequest httpServletRequest) {
+    public GlobalApiResponse<?> login(@Valid @RequestBody LoginRequest request,
+                                      HttpServletRequest httpServletRequest) {
 
         Long userId = authService.login(request);
         HttpSession httpSession = httpServletRequest.getSession();
 
         httpSession.setAttribute("LOGIN_USER", userId);
-        return ResponseEntity.status(HttpStatus.OK).body("로그인 되었습니다.");
+
+        return GlobalApiResponse.ok("로그인 되었습니다.", null);
     }
 
     // 로그아웃
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(HttpServletRequest httpServletRequest) {
+    public GlobalApiResponse<?> logout(HttpServletRequest httpServletRequest) {
 
         HttpSession httpSession = httpServletRequest.getSession(false); // 세션 생성 금지
 
@@ -51,17 +52,17 @@ public class AuthController {
         if (httpSession != null)
             httpSession.invalidate();
 
-        return ResponseEntity.status(HttpStatus.OK).body("로그아웃 되었습니다.");
+        return GlobalApiResponse.ok("로그아웃 되었습니다.", null);
     }
 
     //회원탈퇴
     @DeleteMapping("/withdraw")
-    public ResponseEntity<String> withdraw(@LoginUserResolver User user,
-                                           @Valid @RequestBody DeleteUserRequest request) {
+    public GlobalApiResponse<?> withdraw(@LoginUserResolver User user,
+                                         @Valid @RequestBody DeleteUserRequest request) {
 
         // 로그인된 사용자인 경우, 서비스 로직 호출
         authService.withdraw(user, request);
 
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).body("회원 탈퇴되었습니다.");
+        return GlobalApiResponse.ok("회원탈퇴 되었습니다.", null);
     }
 }

--- a/src/main/java/com/example/newsfeedproject/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/example/newsfeedproject/domain/bookmark/controller/BookmarkController.java
@@ -1,5 +1,6 @@
 package com.example.newsfeedproject.domain.bookmark.controller;
 
+import com.example.newsfeedproject.common.dto.GlobalApiResponse;
 import com.example.newsfeedproject.domain.bookmark.service.BookmarkService;
 import com.example.newsfeedproject.common.annotation.LoginUserResolver;
 import com.example.newsfeedproject.domain.post.dto.PostListResponse;
@@ -8,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,30 +18,30 @@ public class BookmarkController {
     private final BookmarkService bookmarkService;
 
     @PostMapping("/posts/{postId}/bookmarks")
-    public ResponseEntity<String> addBookmark(@LoginUserResolver User user,
-                                              @PathVariable Long postId) {
+    public GlobalApiResponse<?> addBookmark(@LoginUserResolver User user,
+                                         @PathVariable Long postId) {
 
         bookmarkService.addBookmark(user, postId);
 
-        return ResponseEntity.ok().body("북마크가 추가되었습니다.");
+        return GlobalApiResponse.ok("북마크가 추가되었습니다.", null);
     }
 
     @DeleteMapping("/posts/{postId}/bookmarks")
-    public ResponseEntity<String> removeBookmark(@LoginUserResolver User user,
+    public GlobalApiResponse<?> removeBookmark(@LoginUserResolver User user,
                                                  @PathVariable Long postId) {
 
         bookmarkService.removeBookmark(user, postId);
 
-        return ResponseEntity.ok().body("북마크가 삭제되었습니다.");
+        return GlobalApiResponse.ok("북마크가 삭제되었습니다.", null);
     }
 
     @GetMapping("/bookmarks")
-    public ResponseEntity<PostListResponse> getBookmarks(@LoginUserResolver User user,
-                                                         @RequestParam(defaultValue = "0") int page) {
+    public GlobalApiResponse<PostListResponse> getBookmarks(@LoginUserResolver User user,
+                                                            @RequestParam(defaultValue = "0") int page) {
 
         Pageable pageable = PageRequest.of(page, 10, Sort.by("createdAt").descending());
         PostListResponse postListResponse = bookmarkService.getBookmarks(user, pageable);
 
-        return ResponseEntity.ok(postListResponse);
+        return GlobalApiResponse.ok("북마크된 게시물이 조회되었습니다.", postListResponse);
     }
 }

--- a/src/main/java/com/example/newsfeedproject/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/newsfeedproject/domain/comment/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.example.newsfeedproject.domain.comment.controller;
 
+import com.example.newsfeedproject.common.dto.GlobalApiResponse;
 import com.example.newsfeedproject.domain.comment.dto.CommentCreateResponse;
 import com.example.newsfeedproject.domain.comment.dto.CommentListResponse;
 import com.example.newsfeedproject.domain.comment.dto.CommentRequest;
@@ -10,7 +11,6 @@ import com.example.newsfeedproject.domain.user.entity.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -24,45 +24,45 @@ public class CommentController {
 
     // 댓글 생성 기능
     @PostMapping
-    public ResponseEntity<CommentCreateResponse> createComment(@PathVariable Long postId,
-                                                               @RequestBody @Valid CommentRequest commentRequest,
-                                                               @LoginUserResolver User user) {
+    public GlobalApiResponse<CommentCreateResponse> createComment(@PathVariable Long postId,
+                                                                  @RequestBody @Valid CommentRequest commentRequest,
+                                                                  @LoginUserResolver User user) {
 
         CommentCreateResponse commentCreateResponse = commentService.createComment(postId, commentRequest, user);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(commentCreateResponse);
+        return GlobalApiResponse.success(HttpStatus.CREATED, "댓글이 생성되었습니다.", commentCreateResponse);
     }
 
     // 댓글 조회 기능
     @GetMapping
-    public ResponseEntity<List<CommentListResponse>> getComments(@PathVariable Long postId) {
+    public GlobalApiResponse<List<CommentListResponse>> getComments(@PathVariable Long postId) {
 
         List<CommentListResponse> commentListResponse = commentService.getComments(postId);
 
-        return ResponseEntity.ok(commentListResponse);
+        return GlobalApiResponse.ok("게시글 댓글이 조회되었습니다.", commentListResponse);
     }
 
     // 댓글 수정 기능
     @PatchMapping("/{commentId}")
-    public ResponseEntity<CommentUpdateResponse> updateComment(@PathVariable Long postId,
-                                                               @PathVariable Long commentId,
-                                                               @RequestBody @Valid CommentRequest commentRequest,
-                                                               @LoginUserResolver User user) {
+    public GlobalApiResponse<CommentUpdateResponse> updateComment(@PathVariable Long postId,
+                                                                  @PathVariable Long commentId,
+                                                                  @RequestBody @Valid CommentRequest commentRequest,
+                                                                  @LoginUserResolver User user) {
 
         CommentUpdateResponse commentUpdateResponse = commentService.updateComment(commentId, commentRequest, user);
 
-        return ResponseEntity.ok(commentUpdateResponse);
+        return GlobalApiResponse.ok("댓글이 수정되었습니다.", commentUpdateResponse);
     }
 
     // 댓글 삭제 기능
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<String> deleteComment(@PathVariable Long postId,
-                                                @PathVariable Long commentId,
-                                                @LoginUserResolver User user) {
+    public GlobalApiResponse<?> deleteComment(@PathVariable Long postId,
+                                              @PathVariable Long commentId,
+                                              @LoginUserResolver User user) {
 
         commentService.deleteComment(commentId, user);
 
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).body("댓글이 삭제되었습니다.");
+        return GlobalApiResponse.success(HttpStatus.NO_CONTENT, "댓글이 삭제되었습니다.", null);
 
     }
 }

--- a/src/main/java/com/example/newsfeedproject/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/example/newsfeedproject/domain/follow/controller/FollowController.java
@@ -1,12 +1,12 @@
 package com.example.newsfeedproject.domain.follow.controller;
 
 import com.example.newsfeedproject.common.annotation.LoginUserResolver;
+import com.example.newsfeedproject.common.dto.GlobalApiResponse;
 import com.example.newsfeedproject.domain.follow.dto.FollowerResponse;
 import com.example.newsfeedproject.domain.follow.dto.FollowingResponse;
 import com.example.newsfeedproject.domain.follow.service.FollowService;
 import com.example.newsfeedproject.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -20,39 +20,39 @@ public class FollowController {
 
     // 특정 사용자 팔로우
     @PostMapping("/{userId}/follow")
-    public ResponseEntity<String> followUser(@PathVariable Long userId,
-                                             @LoginUserResolver User user) {
+    public GlobalApiResponse<?> followUser(@PathVariable Long userId,
+                                           @LoginUserResolver User user) {
 
         followService.followUser(userId, user);
 
-        return ResponseEntity.ok().body("팔로우 되었습니다.");
+        return GlobalApiResponse.ok("팔로우 되었습니다.", null);
     }
 
     // 특정 사용자 언팔로우
     @DeleteMapping("/{userId}/follow")
-    public ResponseEntity<String> unfollowUser(@PathVariable Long userId,
-                                               @LoginUserResolver User user) {
+    public GlobalApiResponse<?> unfollowUser(@PathVariable Long userId,
+                                             @LoginUserResolver User user) {
 
         followService.unfollowUser(userId, user);
 
-        return ResponseEntity.ok().body("언팔로우 하였습니다.");
+        return GlobalApiResponse.ok("언팔로우 하였습니다.", null);
     }
 
     // 팔로잉 목록 조회
     @GetMapping("/following")
-    public ResponseEntity<List<FollowingResponse>> getFollowingList(@LoginUserResolver User user) {
+    public GlobalApiResponse<List<FollowingResponse>> getFollowingList(@LoginUserResolver User user) {
 
         List<FollowingResponse> followingList = followService.getFollowingList(user);
 
-        return ResponseEntity.ok(followingList);
+        return GlobalApiResponse.ok("팔로잉 목록이 조회되었습니다.", followingList);
     }
 
     // 팔로워 목록 조회
     @GetMapping("/followers")
-    public ResponseEntity<List<FollowerResponse>> getFollowerList(@LoginUserResolver User user) {
+    public GlobalApiResponse<List<FollowerResponse>> getFollowerList(@LoginUserResolver User user) {
 
         List<FollowerResponse> followerList = followService.getFollowerList(user);
 
-        return ResponseEntity.ok(followerList);
+        return GlobalApiResponse.ok("팔로워 목록이 조회되었습니다.", followerList);
     }
 }

--- a/src/main/java/com/example/newsfeedproject/domain/like/controller/LikeController.java
+++ b/src/main/java/com/example/newsfeedproject/domain/like/controller/LikeController.java
@@ -1,13 +1,13 @@
 package com.example.newsfeedproject.domain.like.controller;
 
 import com.example.newsfeedproject.common.annotation.LoginUserResolver;
+import com.example.newsfeedproject.common.dto.GlobalApiResponse;
 import com.example.newsfeedproject.domain.like.dto.LikeResponse;
 import com.example.newsfeedproject.domain.like.dto.LikeListResponse;
 import com.example.newsfeedproject.domain.like.service.LikeService;
 import com.example.newsfeedproject.domain.user.entity.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,26 +18,26 @@ public class LikeController {
     private final LikeService likeService;
 
     @PostMapping
-    public ResponseEntity<LikeResponse> addLike(@LoginUserResolver User user, @Valid @PathVariable Long postId) {
+    public GlobalApiResponse<LikeResponse> addLike(@LoginUserResolver User user, @Valid @PathVariable Long postId) {
 
         LikeResponse addedLikeResponse = likeService.addLike(postId, user.getId());
 
-        return ResponseEntity.ok(addedLikeResponse);
+        return GlobalApiResponse.ok("좋아요가 추가되었습니다.", addedLikeResponse);
     }
 
     @DeleteMapping
-    public ResponseEntity<LikeResponse> deleteLike(@LoginUserResolver User user, @Valid @PathVariable Long postId) {
+    public GlobalApiResponse<LikeResponse> deleteLike(@LoginUserResolver User user, @Valid @PathVariable Long postId) {
 
         LikeResponse deletedLike = likeService.deleteLike(postId, user.getId());
 
-        return ResponseEntity.ok(deletedLike);
+        return GlobalApiResponse.ok("좋아요가 취소되었습니다.", deletedLike);
     }
 
     @GetMapping
-    public ResponseEntity<LikeListResponse> getLike(@Valid @PathVariable Long postId) {
+    public GlobalApiResponse<LikeListResponse> getLike(@Valid @PathVariable Long postId) {
 
         LikeListResponse likeListResponse = likeService.getLikeList(postId);
 
-        return ResponseEntity.ok(likeListResponse);
+        return GlobalApiResponse.ok("게시글 좋아요 목록이 조회되었습니다.", likeListResponse);
     }
 }

--- a/src/main/java/com/example/newsfeedproject/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/newsfeedproject/domain/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.example.newsfeedproject.domain.post.controller;
 
 import com.example.newsfeedproject.common.annotation.LoginUserResolver;
+import com.example.newsfeedproject.common.dto.GlobalApiResponse;
 import com.example.newsfeedproject.domain.post.dto.PostListResponse;
 import com.example.newsfeedproject.domain.post.dto.PostRequest;
 import com.example.newsfeedproject.domain.post.dto.PostResponse;
@@ -13,7 +14,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -27,86 +27,86 @@ public class PostController {
 
     // 뉴스피드 게시물 생성
     @PostMapping
-    public ResponseEntity<PostResponse> createPost(@RequestBody @Valid PostRequest request,
-                                                   @LoginUserResolver User user) {
+    public GlobalApiResponse<PostResponse> createPost(@RequestBody @Valid PostRequest request,
+                                                      @LoginUserResolver User user) {
 
         PostResponse postResponse = postService.createPost(request, user);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(postResponse);
+        return GlobalApiResponse.success(HttpStatus.CREATED, "게시글이 작성되었습니다.", postResponse);
     }
 
     // 뉴스피드 조회 (내가 팔로우한 사용자들의 게시물 최신순)
     @GetMapping("/feed")
-    public ResponseEntity<PostListResponse> getNewsfeed(@LoginUserResolver User user,
-                                                        @RequestParam(defaultValue = "0") int page) {
+    public GlobalApiResponse<PostListResponse> getNewsfeed(@LoginUserResolver User user,
+                                                           @RequestParam(defaultValue = "0") int page) {
 
         Pageable pageable = PageRequest.of(page, 10, Sort.by("createdAt").descending());
 
         PostListResponse response = postService.getNewsfeed(user, pageable);
 
-        return ResponseEntity.ok(response);
+        return GlobalApiResponse.ok("뉴스피드가 성공적으로 조회되었습니다.", response);
     }
 
     // 전체 게시물 조회
     @GetMapping
-    public ResponseEntity<PostListResponse> getPosts(@RequestParam(defaultValue = "0") int page,
-                                                     @RequestParam(defaultValue = "createdAt") String sortBy) {
+    public GlobalApiResponse<PostListResponse> getPosts(@RequestParam(defaultValue = "0") int page,
+                                                        @RequestParam(defaultValue = "createdAt") String sortBy) {
 
         Pageable pageable = PageRequest.of(page, 10, Sort.by(sortBy).descending());
         PostListResponse postListResponse = postService.getPosts(pageable);
 
-        return ResponseEntity.ok(postListResponse);
+        return GlobalApiResponse.ok("전체 게시글이 조회되었습니다.", postListResponse);
     }
 
     // 단건 게시물 조회
     @GetMapping("/{postId}")
-    public ResponseEntity<PostResponse> getPost(@PathVariable Long postId) {
+    public GlobalApiResponse<PostResponse> getPost(@PathVariable Long postId) {
 
         PostResponse postResponseById = postService.getPostById(postId);
 
-        return ResponseEntity.ok(postResponseById);
+        return GlobalApiResponse.ok("단건 게시글이 조회되었습니다.", postResponseById);
     }
 
     // 기간별 게시물 조회 (생성일 기준 최신순)
     @GetMapping("/search/period")
-    public ResponseEntity<PostListResponse> getPostsByPeriod(@RequestParam LocalDateTime startDate,
-                                                             @RequestParam LocalDateTime endDate,
-                                                             @RequestParam(defaultValue = "0") int page) {
+    public GlobalApiResponse<PostListResponse> getPostsByPeriod(@RequestParam LocalDateTime startDate,
+                                                                @RequestParam LocalDateTime endDate,
+                                                                @RequestParam(defaultValue = "0") int page) {
 
         Pageable pageable = PageRequest.of(page, 10, Sort.by("createdAt").descending());
         PostListResponse postListResponseByPeriod = postService.getPostsByPeriod(startDate, endDate, pageable);
 
-        return ResponseEntity.ok(postListResponseByPeriod);
+        return GlobalApiResponse.ok("기간별 게시글이 조회되었습니다.", postListResponseByPeriod);
     }
 
     // 해시태그별 게시물 조회 (생성일 기준 최신순)
     @GetMapping("/search/hashtag")
-    public ResponseEntity<PostListResponse> getPostsByHashtag(@RequestParam String tag,
-                                                              @RequestParam(defaultValue = "0") int page) {
+    public GlobalApiResponse<PostListResponse> getPostsByHashtag(@RequestParam String tag,
+                                                                 @RequestParam(defaultValue = "0") int page) {
 
         Pageable pageable = PageRequest.of(page, 10, Sort.by("createdAt").descending());
         PostListResponse response = postService.getPostsByHashtag(tag, pageable);
-        return ResponseEntity.ok(response);
+        return GlobalApiResponse.ok("특정 해시태그 게시물이 조회되었습니다", response);
     }
 
      // 게시물 내용 수정
     @PatchMapping("/{postId}")
-    public ResponseEntity<PostResponse> updatePostContent(@LoginUserResolver User user,
-                                                          @PathVariable Long postId,
-                                                          @Valid @RequestBody UpdatePostContentRequest request) {
+    public GlobalApiResponse<PostResponse> updatePostContent(@LoginUserResolver User user,
+                                                             @PathVariable Long postId,
+                                                             @Valid @RequestBody UpdatePostContentRequest request) {
 
         PostResponse updatePostContentResponse = postService.updatePostContent(user, postId, request);
 
-        return ResponseEntity.ok(updatePostContentResponse);
+        return GlobalApiResponse.ok("게시글이 수정되었습니다.", updatePostContentResponse);
     }
 
     // 게시물 삭제
     @DeleteMapping("/{postId}")
-    public ResponseEntity<Void> deletePost(@LoginUserResolver User user,
+    public GlobalApiResponse<?> deletePost(@LoginUserResolver User user,
                                            @PathVariable Long postId) {
 
         postService.deletePostById(user, postId);
 
-        return ResponseEntity.noContent().build();
+        return GlobalApiResponse.success(HttpStatus.NO_CONTENT, "게시글이 삭제되었습니다.", null);
     }
 }

--- a/src/main/java/com/example/newsfeedproject/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/newsfeedproject/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.example.newsfeedproject.domain.user.controller;
 
 import com.example.newsfeedproject.common.annotation.LoginUserResolver;
+import com.example.newsfeedproject.common.dto.GlobalApiResponse;
 import com.example.newsfeedproject.domain.user.dto.UpdatePasswordRequest;
 import com.example.newsfeedproject.domain.user.dto.UpdateUserInfoRequest;
 import com.example.newsfeedproject.domain.user.dto.UserResponse;
@@ -8,7 +9,6 @@ import com.example.newsfeedproject.domain.user.entity.User;
 import com.example.newsfeedproject.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,39 +20,39 @@ public class UserController {
 
     // 내 프로필 조회
     @GetMapping("/profile")
-    public ResponseEntity<UserResponse> getUserInfo(@LoginUserResolver User user) {
+    public GlobalApiResponse<UserResponse> getUserInfo(@LoginUserResolver User user) {
 
         UserResponse profileResponse = userService.getUserInfo(user.getId());
 
-        return ResponseEntity.ok(profileResponse);
+        return GlobalApiResponse.ok("유저 정보가 조회되었습니다.", profileResponse);
     }
 
     // 유저 정보 조회
     @GetMapping("/{userId}")
-    public ResponseEntity<UserResponse> getUserInfo(@PathVariable Long userId) {
+    public GlobalApiResponse<UserResponse> getUserInfo(@PathVariable Long userId) {
 
         UserResponse userInfoResponse = userService.getUserInfo(userId);
 
-        return ResponseEntity.ok(userInfoResponse);
+        return GlobalApiResponse.ok("유저 정보가 조회되었습니다.", userInfoResponse);
     }
 
     // 유저 정보 수정
     @PatchMapping
-    public ResponseEntity<UserResponse> updateUserInfo(@LoginUserResolver User user,
-                                                       @RequestBody @Valid UpdateUserInfoRequest request) {
+    public GlobalApiResponse<UserResponse> updateUserInfo(@LoginUserResolver User user,
+                                                          @RequestBody @Valid UpdateUserInfoRequest request) {
 
         UserResponse updateUserResponse = userService.updateUserInfo(user.getId(), request);
 
-        return ResponseEntity.ok(updateUserResponse);
+        return GlobalApiResponse.ok("유저 정보가 수정되었습니다.", updateUserResponse);
     }
 
     // 비밀번호 변경
     @PatchMapping("/password")
-    public ResponseEntity<String> updatePassword(@LoginUserResolver User user,
+    public GlobalApiResponse<String> updatePassword(@LoginUserResolver User user,
                                                @RequestBody @Valid UpdatePasswordRequest request) {
 
         userService.updatePassword(user.getId(), request);
 
-        return ResponseEntity.ok().body("비밀번호가 변경되었습니다.");
+        return GlobalApiResponse.ok("비밀번호가 변경되었습니다.", null);
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- API 작동 성공 및 실패시 공통적인 형식으로 반환되는 GlobalApiResponse 적용

- 예시
```json
{
    "status": "OK",
    "message": "유저 정보가 조회되었습니다.",
    "data": {
        "id": 1,
        "name": "이름",
        "email": "abcd@gmail.com",
        "age": 60,
        "createdAt": "2025-08-21T14:31:16.218113",
        "modifiedAt": "2025-08-21T14:31:16.218113"
    },
    "timestamp": "2025-08-22T13:43:02.7946374",
    "code": 200
}
```
```json
{
    "status": "AUTH-002",
    "message": "이미 존재하는 이메일입니다.",
    "data": null,
    "timestamp": "2025-08-22T13:54:58.5831607",
    "code": 400
}
```

## 🔗 연관된 이슈
Related to: #93 

## 리뷰 요구사항 (선택)
- 반환 메시지를 확인해보시면 될 것 같습니다.

## ✅ PR 유형

- [x] 새로운 기능 추가
- [x] 코드 리팩토링