### PR TITLE
2차 테스트 및 수정

### DIFF
--- a/src/main/java/com/example/newsfeedproject/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/newsfeedproject/common/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
 
     USER_NOT_FOUND("AUTH-001", "사용자를 찾지 못했습니다.", HttpStatus.NOT_FOUND),
     EMAIL_ALREADY_EXISTS("AUTH-002", "이미 존재하는 이메일입니다.", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED_USER("AUTH-003", "사용할 수 없는 사용자입니다.", HttpStatus.UNAUTHORIZED),
 
     PASSWORD_INCORRECT("USR-001", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
     PASSWORD_NOT_AVAILABLE("USR-002", "새 비밀번호는 현재 비밀번호와 달라야 합니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/example/newsfeedproject/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/newsfeedproject/common/exception/ErrorCode.java
@@ -30,7 +30,11 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND("CMT-001", "댓글이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
     FORBIDDEN_COMMENT("CMT-002", "댓글 수정 또는 삭제 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
-    HASHTAG_NOT_FOUND("TAG-001", "존재하지 않는 해시태그입니다.", HttpStatus.NOT_FOUND);
+    HASHTAG_NOT_FOUND("TAG-001", "존재하지 않는 해시태그입니다.", HttpStatus.NOT_FOUND),
+
+    CANNOT_LIKE_SELF("LIKE-001", "본인 게시물에 좋아요를 누를 수 없습니다.", HttpStatus.CONFLICT),
+    ALREADY_LIKE_APPLIED("LIKE-002", "이미 좋아요된 게시물입니다.", HttpStatus.BAD_REQUEST),
+    LIKE_NOT_APPLIED("LIKE-003", "좋아요가 되어있지 않은 게시물입니다.", HttpStatus.BAD_REQUEST),;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/example/newsfeedproject/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/newsfeedproject/domain/auth/controller/AuthController.java
@@ -46,23 +46,33 @@ public class AuthController {
     @PostMapping("/logout")
     public GlobalApiResponse<?> logout(HttpServletRequest httpServletRequest) {
 
+        sessionLogoutApply(httpServletRequest);
+
+        return GlobalApiResponse.ok("로그아웃 되었습니다.", null);
+    }
+
+    // 회원탈퇴
+    @DeleteMapping("/withdraw")
+    public GlobalApiResponse<?> withdraw(@LoginUserResolver User user,
+                                         @Valid @RequestBody DeleteUserRequest request,
+                                         HttpServletRequest httpServletRequest) {
+
+        // 로그인된 사용자인 경우, 서비스 로직 호출한 뒤 로그아웃 적용
+        authService.withdraw(user, request);
+        sessionLogoutApply(httpServletRequest);
+
+        return GlobalApiResponse.ok("회원탈퇴 되었습니다.", null);
+    }
+
+    /**
+     * 로그아웃 또는 회원 탈퇴시 세션 삭제
+     */
+    public void sessionLogoutApply(HttpServletRequest httpServletRequest) {
+
         HttpSession httpSession = httpServletRequest.getSession(false); // 세션 생성 금지
 
         // 로그인이 되어있는 경우 세션 삭제
         if (httpSession != null)
             httpSession.invalidate();
-
-        return GlobalApiResponse.ok("로그아웃 되었습니다.", null);
-    }
-
-    //회원탈퇴
-    @DeleteMapping("/withdraw")
-    public GlobalApiResponse<?> withdraw(@LoginUserResolver User user,
-                                         @Valid @RequestBody DeleteUserRequest request) {
-
-        // 로그인된 사용자인 경우, 서비스 로직 호출
-        authService.withdraw(user, request);
-
-        return GlobalApiResponse.ok("회원탈퇴 되었습니다.", null);
     }
 }

--- a/src/main/java/com/example/newsfeedproject/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/newsfeedproject/domain/auth/service/AuthService.java
@@ -39,6 +39,8 @@ public class AuthService {
 
         User user = userService.findUserByEmail(loginRequest.email());
 
+        // 사용할 수 있는 계정 확인 -> 비밀번호 확인
+        throwIfUserIsNotUsable(user);
         throwIfPasswordMismatch(loginRequest.password(), user.getPassword());
 
         return user.getId();
@@ -57,5 +59,10 @@ public class AuthService {
     public void throwIfPasswordMismatch(String rawPassword, String encodedPassword) {
         if (!passwordEncoder.matches(rawPassword, encodedPassword))
             throw new BusinessException(ErrorCode.PASSWORD_INCORRECT);
+    }
+
+    public void throwIfUserIsNotUsable(User user) {
+        if (!user.isUsable())
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_USER);
     }
 }

--- a/src/main/java/com/example/newsfeedproject/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/example/newsfeedproject/domain/bookmark/controller/BookmarkController.java
@@ -19,7 +19,7 @@ public class BookmarkController {
 
     @PostMapping("/posts/{postId}/bookmarks")
     public GlobalApiResponse<?> addBookmark(@LoginUserResolver User user,
-                                         @PathVariable Long postId) {
+                                            @PathVariable Long postId) {
 
         bookmarkService.addBookmark(user, postId);
 
@@ -28,7 +28,7 @@ public class BookmarkController {
 
     @DeleteMapping("/posts/{postId}/bookmarks")
     public GlobalApiResponse<?> removeBookmark(@LoginUserResolver User user,
-                                                 @PathVariable Long postId) {
+                                               @PathVariable Long postId) {
 
         bookmarkService.removeBookmark(user, postId);
 

--- a/src/main/java/com/example/newsfeedproject/domain/like/controller/LikeController.java
+++ b/src/main/java/com/example/newsfeedproject/domain/like/controller/LikeController.java
@@ -20,7 +20,7 @@ public class LikeController {
     @PostMapping
     public GlobalApiResponse<LikeResponse> addLike(@LoginUserResolver User user, @Valid @PathVariable Long postId) {
 
-        LikeResponse addedLikeResponse = likeService.addLike(postId, user.getId());
+        LikeResponse addedLikeResponse = likeService.addLike(user.getId(), postId);
 
         return GlobalApiResponse.ok("좋아요가 추가되었습니다.", addedLikeResponse);
     }
@@ -28,7 +28,7 @@ public class LikeController {
     @DeleteMapping
     public GlobalApiResponse<LikeResponse> deleteLike(@LoginUserResolver User user, @Valid @PathVariable Long postId) {
 
-        LikeResponse deletedLike = likeService.deleteLike(postId, user.getId());
+        LikeResponse deletedLike = likeService.deleteLike(user.getId(), postId);
 
         return GlobalApiResponse.ok("좋아요가 취소되었습니다.", deletedLike);
     }

--- a/src/main/java/com/example/newsfeedproject/domain/like/controller/LikeController.java
+++ b/src/main/java/com/example/newsfeedproject/domain/like/controller/LikeController.java
@@ -18,7 +18,7 @@ public class LikeController {
     private final LikeService likeService;
 
     @PostMapping
-    public GlobalApiResponse<LikeResponse> addLike(@LoginUserResolver User user, @Valid @PathVariable Long postId) {
+    public GlobalApiResponse<LikeResponse> addLike(@LoginUserResolver User user, @PathVariable Long postId) {
 
         LikeResponse addedLikeResponse = likeService.addLike(user.getId(), postId);
 
@@ -26,7 +26,7 @@ public class LikeController {
     }
 
     @DeleteMapping
-    public GlobalApiResponse<LikeResponse> deleteLike(@LoginUserResolver User user, @Valid @PathVariable Long postId) {
+    public GlobalApiResponse<LikeResponse> deleteLike(@LoginUserResolver User user,@PathVariable Long postId) {
 
         LikeResponse deletedLike = likeService.deleteLike(user.getId(), postId);
 
@@ -34,7 +34,7 @@ public class LikeController {
     }
 
     @GetMapping
-    public GlobalApiResponse<LikeListResponse> getLike(@Valid @PathVariable Long postId) {
+    public GlobalApiResponse<LikeListResponse> getLike(@PathVariable Long postId) {
 
         LikeListResponse likeListResponse = likeService.getLikeList(postId);
 

--- a/src/main/java/com/example/newsfeedproject/domain/like/service/LikeService.java
+++ b/src/main/java/com/example/newsfeedproject/domain/like/service/LikeService.java
@@ -13,12 +13,10 @@ import com.example.newsfeedproject.domain.user.entity.User;
 import com.example.newsfeedproject.domain.user.service.UserServiceApi;
 import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 

--- a/src/main/java/com/example/newsfeedproject/domain/like/service/LikeService.java
+++ b/src/main/java/com/example/newsfeedproject/domain/like/service/LikeService.java
@@ -1,5 +1,7 @@
 package com.example.newsfeedproject.domain.like.service;
 
+import com.example.newsfeedproject.common.exception.BusinessException;
+import com.example.newsfeedproject.common.exception.ErrorCode;
 import com.example.newsfeedproject.domain.like.dto.LikeResponse;
 import com.example.newsfeedproject.domain.like.dto.LikeListResponse;
 import com.example.newsfeedproject.domain.like.entity.Like;
@@ -45,11 +47,11 @@ public class LikeService {
                     Post post = postService.findPostByIdOrElseThrow(postId);
 
                     if (post.getUser().getId().equals(userId))
-                        throw new ResponseStatusException(HttpStatus.CONFLICT, "본인 게시물에 좋아요를 누를 수 없습니다.");
+                        throw new BusinessException(ErrorCode.CANNOT_LIKE_SELF);
 
                     // 이미 좋아요 되어 있는 경우
                     if (likeRepository.findByUserIdAndPostId(userId, postId).isPresent())
-                        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미 좋아요된 게시물입니다.");
+                        throw new BusinessException(ErrorCode.ALREADY_LIKE_APPLIED);
 
                     User user = userService.findUserByIdOrElseThrow(userId);
                     post.increaseLikes();
@@ -79,7 +81,7 @@ public class LikeService {
                     Post post = postService.findPostByIdOrElseThrow(postId);
 
                     if (likeRepository.findByUserIdAndPostId(userId, postId).isEmpty())
-                        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미 좋아요 취소된 게시물입니다.");
+                        throw new BusinessException(ErrorCode.LIKE_NOT_APPLIED);
 
                     likeRepository.deleteByUserIdAndPostId(userId, postId);
 

--- a/src/main/java/com/example/newsfeedproject/domain/post/entity/Post.java
+++ b/src/main/java/com/example/newsfeedproject/domain/post/entity/Post.java
@@ -6,10 +6,13 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicInsert
 public class Post extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,6 +24,7 @@ public class Post extends BaseEntity {
     @Column(nullable = false, length = 300)
     private String content;
 
+    @ColumnDefault("'0'")
     private Long likesCount;
 
     // @Version 필드는 JPA가 내부적으로 사용하기 때문에, 실제 코드에서 직접 접근하지 않아도 동작합니다.

--- a/src/main/java/com/example/newsfeedproject/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/newsfeedproject/domain/user/controller/UserController.java
@@ -49,7 +49,7 @@ public class UserController {
     // 비밀번호 변경
     @PatchMapping("/password")
     public GlobalApiResponse<String> updatePassword(@LoginUserResolver User user,
-                                               @RequestBody @Valid UpdatePasswordRequest request) {
+                                                    @RequestBody @Valid UpdatePasswordRequest request) {
 
         userService.updatePassword(user.getId(), request);
 


### PR DESCRIPTION
## 📝 작업 내용
- Like 컨트롤러 파라미터 순서 오류 수정
- Post likstCount 필드 기본값 0 저장
- 불필요한 Valid 어노테이션 제거
- 파라미터 줄 간격 수정
- 회원 탈퇴시 세션 로그아웃 적용, 탈퇴 사용자 로그인 시도 -> 예외 처리
- Like 서비스 예외를 GlobalHandler로 처리
- 불필요한 import 제거

## 🔗 연관된 이슈
Related to: #97 

## ✅ PR 유형
- [x] 코드 리팩토링
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)