### PR TITLE
JWT 토큰 방식 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,11 @@ dependencies {
     // BCrypt
     implementation 'at.favre.lib:bcrypt:0.10.2'
 
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/example/newsfeedproject/common/config/UserMethodArgumentResolver.java
+++ b/src/main/java/com/example/newsfeedproject/common/config/UserMethodArgumentResolver.java
@@ -3,7 +3,6 @@ package com.example.newsfeedproject.common.config;
 import com.example.newsfeedproject.common.exception.BusinessException;
 import com.example.newsfeedproject.common.exception.ErrorCode;
 import com.example.newsfeedproject.domain.user.entity.User;
-import com.example.newsfeedproject.domain.user.repository.UserRepository;
 import com.example.newsfeedproject.domain.user.service.UserServiceApi;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +17,7 @@ import java.util.Objects;
 
 @Component
 @RequiredArgsConstructor
-public class UserHandlerArgumentResolver implements HandlerMethodArgumentResolver {
+public class UserMethodArgumentResolver implements HandlerMethodArgumentResolver {
 
     private final HttpSession httpSession;
     private final UserServiceApi userService;

--- a/src/main/java/com/example/newsfeedproject/common/config/UserMethodArgumentResolver.java
+++ b/src/main/java/com/example/newsfeedproject/common/config/UserMethodArgumentResolver.java
@@ -45,6 +45,11 @@ public class UserMethodArgumentResolver implements HandlerMethodArgumentResolver
         String token = header.substring("Bearer ".length());
         long userId = jwtUtil.getUserIdFromToken(token);
 
-        return userService.findUserByIdOrElseThrow(userId);
+        User user = userService.findUserByIdOrElseThrow(userId);
+
+        if (!user.isUsable())
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_USER);
+
+        return user;
     }
 }

--- a/src/main/java/com/example/newsfeedproject/common/config/WebConfig.java
+++ b/src/main/java/com/example/newsfeedproject/common/config/WebConfig.java
@@ -11,11 +11,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    private final UserHandlerArgumentResolver userHandlerArgumentResolver;
+    private final UserMethodArgumentResolver userMethodArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
 
-        resolvers.add(userHandlerArgumentResolver);
+        resolvers.add(userMethodArgumentResolver);
     }
 }

--- a/src/main/java/com/example/newsfeedproject/common/security/JwtUtil.java
+++ b/src/main/java/com/example/newsfeedproject/common/security/JwtUtil.java
@@ -1,0 +1,36 @@
+package com.example.newsfeedproject.common.security;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private final String SECRET_KEY;
+
+    public JwtUtil(@Value("${jwt.secret}") String secretKey) {
+        this.SECRET_KEY = secretKey;
+    }
+
+    // 토큰 발급
+    public String createToken(long userId) {
+
+        SecretKey secretKey = Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
+        long TOKEN_VALIDITY_IN_SECONDS = 1000 * 60 * 60;
+
+        Date now = new Date();
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(now)
+                .expiration(new Date(TOKEN_VALIDITY_IN_SECONDS))
+                .signWith(secretKey, Jwts.SIG.HS256)
+                .compact();
+    }
+}

--- a/src/main/java/com/example/newsfeedproject/common/security/JwtUtil.java
+++ b/src/main/java/com/example/newsfeedproject/common/security/JwtUtil.java
@@ -1,8 +1,10 @@
 package com.example.newsfeedproject.common.security;
 
+import com.example.newsfeedproject.common.exception.BusinessException;
+import com.example.newsfeedproject.common.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -12,25 +14,36 @@ import java.util.Date;
 @Component
 public class JwtUtil {
 
-    private final String SECRET_KEY;
-
-    public JwtUtil(@Value("${jwt.secret}") String secretKey) {
-        this.SECRET_KEY = secretKey;
-    }
+    private static final SecretKey SECRET_KEY =
+            Keys.hmacShaKeyFor("64K07J2867Cw7JuA7Lqg7ZSEMTDsobDribTsiqTtlLzrk5ztlITroZzsoJ3tirg".getBytes(StandardCharsets.UTF_8));
 
     // 토큰 발급
     public String createToken(long userId) {
 
-        SecretKey secretKey = Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
-        long TOKEN_VALIDITY_IN_SECONDS = 1000 * 60 * 60;
-
         Date now = new Date();
+        long TOKEN_VALIDITY_IN_SECONDS = 1000 * 60 * 60;
 
         return Jwts.builder()
                 .subject(String.valueOf(userId))
                 .issuedAt(now)
-                .expiration(new Date(TOKEN_VALIDITY_IN_SECONDS))
-                .signWith(secretKey, Jwts.SIG.HS256)
+                .expiration(new Date(now.getTime() + TOKEN_VALIDITY_IN_SECONDS))
+                .signWith(SECRET_KEY, Jwts.SIG.HS256)
                 .compact();
+    }
+
+    // 토큰으로 사용자 id 값 반환
+    public long getUserIdFromToken(String token) {
+
+        Claims claims = Jwts.parser()
+                .verifyWith(SECRET_KEY)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        try {
+            return Long.parseLong(claims.getSubject());
+        } catch (NumberFormatException e) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/com/example/newsfeedproject/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/newsfeedproject/domain/auth/controller/AuthController.java
@@ -7,8 +7,6 @@ import com.example.newsfeedproject.domain.user.dto.DeleteUserRequest;
 import com.example.newsfeedproject.domain.user.dto.LoginRequest;
 import com.example.newsfeedproject.domain.user.dto.SignupRequest;
 import com.example.newsfeedproject.domain.user.entity.User;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
+
     private final AuthService authService;
 
     // 회원가입
@@ -40,9 +39,7 @@ public class AuthController {
 
     // 로그아웃
     @PostMapping("/logout")
-    public GlobalApiResponse<?> logout(HttpServletRequest httpServletRequest) {
-
-        sessionLogoutApply(httpServletRequest);
+    public GlobalApiResponse<?> logout() {
 
         return GlobalApiResponse.ok("로그아웃 되었습니다.", null);
     }
@@ -50,25 +47,10 @@ public class AuthController {
     // 회원탈퇴
     @DeleteMapping("/withdraw")
     public GlobalApiResponse<?> withdraw(@LoginUserResolver User user,
-                                         @Valid @RequestBody DeleteUserRequest request,
-                                         HttpServletRequest httpServletRequest) {
+                                         @Valid @RequestBody DeleteUserRequest request) {
 
-        // 로그인된 사용자인 경우, 서비스 로직 호출한 뒤 로그아웃 적용
         authService.withdraw(user, request);
-        sessionLogoutApply(httpServletRequest);
 
         return GlobalApiResponse.ok("회원탈퇴 되었습니다.", null);
-    }
-
-    /**
-     * 로그아웃 또는 회원 탈퇴시 세션 삭제
-     */
-    public void sessionLogoutApply(HttpServletRequest httpServletRequest) {
-
-        HttpSession httpSession = httpServletRequest.getSession(false); // 세션 생성 금지
-
-        // 로그인이 되어있는 경우 세션 삭제
-        if (httpSession != null)
-            httpSession.invalidate();
     }
 }

--- a/src/main/java/com/example/newsfeedproject/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/newsfeedproject/domain/auth/controller/AuthController.java
@@ -31,15 +31,11 @@ public class AuthController {
 
     // 로그인
     @PostMapping("/login")
-    public GlobalApiResponse<?> login(@Valid @RequestBody LoginRequest request,
-                                      HttpServletRequest httpServletRequest) {
+    public GlobalApiResponse<?> login(@Valid @RequestBody LoginRequest request) {
 
-        Long userId = authService.login(request);
-        HttpSession httpSession = httpServletRequest.getSession();
+        String token = authService.login(request);
 
-        httpSession.setAttribute("LOGIN_USER", userId);
-
-        return GlobalApiResponse.ok("로그인 되었습니다.", null);
+        return GlobalApiResponse.ok("로그인 되었습니다.", token);
     }
 
     // 로그아웃

--- a/src/main/java/com/example/newsfeedproject/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/newsfeedproject/domain/auth/service/AuthService.java
@@ -3,6 +3,7 @@ package com.example.newsfeedproject.domain.auth.service;
 import com.example.newsfeedproject.common.config.PasswordEncoder;
 import com.example.newsfeedproject.common.exception.BusinessException;
 import com.example.newsfeedproject.common.exception.ErrorCode;
+import com.example.newsfeedproject.common.security.JwtUtil;
 import com.example.newsfeedproject.domain.user.dto.LoginRequest;
 import com.example.newsfeedproject.domain.user.mapper.UserMapper;
 import com.example.newsfeedproject.domain.user.dto.DeleteUserRequest;
@@ -19,6 +20,7 @@ public class AuthService {
 
     private final PasswordEncoder passwordEncoder;
     private final UserMapper userMapper;
+    private final JwtUtil jwtUtil;
     private final UserServiceApi userService;
 
     @Transactional
@@ -35,7 +37,7 @@ public class AuthService {
     }
 
     @Transactional
-    public Long login(LoginRequest loginRequest) {
+    public String login(LoginRequest loginRequest) {
 
         User user = userService.findUserByEmail(loginRequest.email());
 
@@ -43,7 +45,7 @@ public class AuthService {
         throwIfUserIsNotUsable(user);
         throwIfPasswordMismatch(loginRequest.password(), user.getPassword());
 
-        return user.getId();
+        return jwtUtil.createToken(user.getId());
     }
 
     @Transactional


### PR DESCRIPTION
## 📝 작업 내용
- JWT 의존성을 추가합니다.
- JwtUtil에서 토큰을 발급하거나 발급된 토큰으로 유저의 id값을 가져옵니다.
- Auth Service의 login API가 성공시 토큰 데이터가 포함됩니다.
- 만약 postman으로 테스트 하려는 경우, 로그인시 발급되는 토큰 값을 다른 API의 Authorization에 작성해야 합니다.
  - Auth Type : Bearer Type으로 수정합니다.
  - Token에 발급받았던 토큰 값을 넣습니다.

## 🔗 연관된 이슈
Related to: #102 

## 리뷰 요구사항 (선택)
- 별개의 ErrorCode를 추가하지 않았습니다.
- UserMethodArgumentResolver, JwtUtil 클래스에 적힌 BusinessException에 들어갈 적당한 ErrorCode를 만들어서 붙이셔도 될 것 같습니다.
  - 만약 직접 추가하려는 경우, `dev`를 pull하고 `feat/jwt-token`으로 전환한 뒤 내용을 수정해서 commit/push 하시면 됩니다.

## ✅ PR 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링