### PR TITLE
보안 강화를 위한 RefreshToken 적용

### DIFF
--- a/src/main/java/com/example/newsfeedproject/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/newsfeedproject/common/exception/ErrorCode.java
@@ -11,6 +11,9 @@ public enum ErrorCode {
     USER_NOT_FOUND("AUTH-001", "사용자를 찾지 못했습니다.", HttpStatus.NOT_FOUND),
     EMAIL_ALREADY_EXISTS("AUTH-002", "이미 존재하는 이메일입니다.", HttpStatus.BAD_REQUEST),
     UNAUTHORIZED_USER("AUTH-003", "사용할 수 없는 사용자입니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_REFRESH_TOKEN("AUTH-004", "유효하지 않은 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_ACCESS_TOKEN("AUTH-005", "유효하지 않은 액세스 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    TOKEN_EXPIRED("AUTH-006", "만료된 토큰입니다.", HttpStatus.UNAUTHORIZED),
 
     PASSWORD_INCORRECT("USR-001", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
     PASSWORD_NOT_AVAILABLE("USR-002", "새 비밀번호는 현재 비밀번호와 달라야 합니다.", HttpStatus.BAD_REQUEST),
@@ -34,7 +37,7 @@ public enum ErrorCode {
 
     CANNOT_LIKE_SELF("LIKE-001", "본인 게시물에 좋아요를 누를 수 없습니다.", HttpStatus.CONFLICT),
     ALREADY_LIKE_APPLIED("LIKE-002", "이미 좋아요된 게시물입니다.", HttpStatus.BAD_REQUEST),
-    LIKE_NOT_APPLIED("LIKE-003", "좋아요가 되어있지 않은 게시물입니다.", HttpStatus.BAD_REQUEST),;
+    LIKE_NOT_APPLIED("LIKE-003", "좋아요가 되어있지 않은 게시물입니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/example/newsfeedproject/common/security/CookieUtil.java
+++ b/src/main/java/com/example/newsfeedproject/common/security/CookieUtil.java
@@ -1,0 +1,47 @@
+package com.example.newsfeedproject.common.security;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+
+    public void addHttpOnlyCookie(HttpServletResponse response, String value) {
+
+        ResponseCookie cookie = ResponseCookie.from(JwtConstants.REFRESH_TOKEN, value)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .sameSite("Strict")
+                .maxAge(JwtConstants.REFRESH_TOKEN_EXPIRATION / 1000)
+                .build();
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    public void deleteCookie(HttpServletResponse response) {
+
+        ResponseCookie cookie = ResponseCookie.from(JwtConstants.REFRESH_TOKEN, "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .sameSite("Strict")
+                .maxAge(0)
+                .build();
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    public String getCookieValue(HttpServletRequest request) {
+
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if (cookie.getName().equals(JwtConstants.REFRESH_TOKEN)) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/newsfeedproject/common/security/JwtConstants.java
+++ b/src/main/java/com/example/newsfeedproject/common/security/JwtConstants.java
@@ -1,0 +1,9 @@
+package com.example.newsfeedproject.common.security;
+
+public class JwtConstants {
+
+    public static final String Secret = "64K07J2867Cw7JuA7Lqg7ZSEMTDsobDribTsiqTtlLzrk5ztlITroZzsoJ3tirg";
+    public static final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 15;
+    public static final long REFRESH_TOKEN_EXPIRATION = 1000L * 60 * 60 * 24 * 7;
+    public static final String REFRESH_TOKEN = "refreshToken";
+}

--- a/src/main/java/com/example/newsfeedproject/common/security/JwtUtil.java
+++ b/src/main/java/com/example/newsfeedproject/common/security/JwtUtil.java
@@ -15,18 +15,30 @@ import java.util.Date;
 public class JwtUtil {
 
     private static final SecretKey SECRET_KEY =
-            Keys.hmacShaKeyFor("64K07J2867Cw7JuA7Lqg7ZSEMTDsobDribTsiqTtlLzrk5ztlITroZzsoJ3tirg".getBytes(StandardCharsets.UTF_8));
+            Keys.hmacShaKeyFor(JwtConstants.Secret.getBytes(StandardCharsets.UTF_8));
 
-    // 토큰 발급
-    public String createToken(long userId) {
+    // 액세스 토큰 발급
+    public String createAccessToken(long userId) {
 
         Date now = new Date();
-        long TOKEN_VALIDITY_IN_SECONDS = 1000 * 60 * 60;
 
         return Jwts.builder()
                 .subject(String.valueOf(userId))
                 .issuedAt(now)
-                .expiration(new Date(now.getTime() + TOKEN_VALIDITY_IN_SECONDS))
+                .expiration(new Date(now.getTime() + JwtConstants.ACCESS_TOKEN_EXPIRATION))
+                .signWith(SECRET_KEY, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    // 리프레시 토큰 발급
+    public String createRefreshToken(long userId) {
+
+        Date now = new Date();
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + JwtConstants.REFRESH_TOKEN_EXPIRATION))
                 .signWith(SECRET_KEY, Jwts.SIG.HS256)
                 .compact();
     }

--- a/src/main/java/com/example/newsfeedproject/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/newsfeedproject/domain/auth/controller/AuthController.java
@@ -2,11 +2,18 @@ package com.example.newsfeedproject.domain.auth.controller;
 
 import com.example.newsfeedproject.common.annotation.LoginUserResolver;
 import com.example.newsfeedproject.common.dto.GlobalApiResponse;
+import com.example.newsfeedproject.common.exception.BusinessException;
+import com.example.newsfeedproject.common.exception.ErrorCode;
+import com.example.newsfeedproject.common.security.CookieUtil;
+import com.example.newsfeedproject.common.security.JwtUtil;
+import com.example.newsfeedproject.domain.auth.dto.TokenResponse;
 import com.example.newsfeedproject.domain.auth.service.AuthService;
 import com.example.newsfeedproject.domain.user.dto.DeleteUserRequest;
 import com.example.newsfeedproject.domain.user.dto.LoginRequest;
 import com.example.newsfeedproject.domain.user.dto.SignupRequest;
 import com.example.newsfeedproject.domain.user.entity.User;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,6 +25,8 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtUtil jwtUtil;
+    private final CookieUtil cookieUtil;
 
     // 회원가입
     @PostMapping("/signup")
@@ -30,27 +39,44 @@ public class AuthController {
 
     // 로그인
     @PostMapping("/login")
-    public GlobalApiResponse<?> login(@Valid @RequestBody LoginRequest request) {
+    public GlobalApiResponse<?> login(@Valid @RequestBody LoginRequest request,
+                                      HttpServletResponse response) {
 
-        String token = authService.login(request);
+        TokenResponse tokens = authService.login(request);
+        cookieUtil.addHttpOnlyCookie(response, tokens.refreshToken());
 
-        return GlobalApiResponse.ok("로그인 되었습니다.", token);
+        return GlobalApiResponse.ok("로그인 되었습니다.", tokens.accessToken());
     }
 
     // 로그아웃
     @PostMapping("/logout")
-    public GlobalApiResponse<?> logout() {
+    public GlobalApiResponse<?> logout(@LoginUserResolver User user,
+                                       HttpServletResponse response) {
 
+        cookieUtil.deleteCookie(response);
         return GlobalApiResponse.ok("로그아웃 되었습니다.", null);
     }
 
     // 회원탈퇴
     @DeleteMapping("/withdraw")
     public GlobalApiResponse<?> withdraw(@LoginUserResolver User user,
-                                         @Valid @RequestBody DeleteUserRequest request) {
+                                         @Valid @RequestBody DeleteUserRequest request,
+                                         HttpServletResponse response) {
 
         authService.withdraw(user, request);
 
         return GlobalApiResponse.ok("회원탈퇴 되었습니다.", null);
+    }
+
+    @PostMapping("/refresh")
+    public GlobalApiResponse<?> refresh(HttpServletRequest request) {
+        String refreshToken = cookieUtil.getCookieValue(request);
+        if (refreshToken == null)
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+
+        long userId = jwtUtil.getUserIdFromToken(refreshToken);
+        String newAccessToken = jwtUtil.createAccessToken(userId);
+
+        return GlobalApiResponse.ok("토큰 재발급 완료", newAccessToken);
     }
 }

--- a/src/main/java/com/example/newsfeedproject/domain/auth/dto/TokenResponse.java
+++ b/src/main/java/com/example/newsfeedproject/domain/auth/dto/TokenResponse.java
@@ -1,0 +1,7 @@
+package com.example.newsfeedproject.domain.auth.dto;
+
+public record TokenResponse(
+
+        String accessToken,
+        String refreshToken
+) {}

--- a/src/main/java/com/example/newsfeedproject/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/newsfeedproject/domain/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import com.example.newsfeedproject.common.config.PasswordEncoder;
 import com.example.newsfeedproject.common.exception.BusinessException;
 import com.example.newsfeedproject.common.exception.ErrorCode;
 import com.example.newsfeedproject.common.security.JwtUtil;
+import com.example.newsfeedproject.domain.auth.dto.TokenResponse;
 import com.example.newsfeedproject.domain.user.dto.LoginRequest;
 import com.example.newsfeedproject.domain.user.mapper.UserMapper;
 import com.example.newsfeedproject.domain.user.dto.DeleteUserRequest;
@@ -37,15 +38,17 @@ public class AuthService {
     }
 
     @Transactional
-    public String login(LoginRequest loginRequest) {
+    public TokenResponse login(LoginRequest loginRequest) {
 
         User user = userService.findUserByEmail(loginRequest.email());
-
         // 사용할 수 있는 계정 확인 -> 비밀번호 확인
         throwIfUserIsNotUsable(user);
         throwIfPasswordMismatch(loginRequest.password(), user.getPassword());
 
-        return jwtUtil.createToken(user.getId());
+        String accessToken = jwtUtil.createAccessToken(user.getId());
+        String refreshToken = jwtUtil.createRefreshToken(user.getId());
+
+        return new TokenResponse(accessToken, refreshToken);
     }
 
     @Transactional


### PR DESCRIPTION
## 📝 작업 내용
- UserMethodArgumentResolver에 토큰 만료 예외처리 추가
- 토큰 관련 에러코드 3개 추가
- JwtConstants 클래스로 상수들 관리
- AuthController 토큰 만료 시 재발급 로직 추가
- AccessToken과 RefreshToken을 담을 DTO 생성
- RefreshToken을 쿠키에 저장하기 위한 CookieUtil 클래스 추가

<!---- 스크린샷 (선택) -->

## 🔗 연관된 이슈
Related to: #105

<!---- 리뷰 요구사항 (선택) -->

<!---- 현재 버그 (선택) -->

## ✅ PR 유형

- [x] 새로운 기능 추가
- [x] 코드 리팩토링